### PR TITLE
feat: supervised restarts, error categories, and WebUI download history

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: verify
+description: 验证 StickerDownloader 的 Telegram Bot 回调处理
+---
+
+# StickerDownloader 验证
+
+## 常规检查
+
+从仓库任意目录运行：
+
+```bash
+go -C src test ./...
+```
+
+## Telegram 回调端到端验证
+
+Bot 通过长轮询接收更新。安全验证 handler 时，应使用本地 Telegram Bot API 模拟器和假 token：
+
+1. 构建当前工作树的真实二进制，不修改源码，也不要复制真实 `config/config.yaml`。
+2. 用最小假配置启动应用（HTTP server disabled），将 `telegram.api_endpoint` 指向本地模拟器。
+3. 模拟 `getMe`、`getUpdates`、`answerCallbackQuery` 以及目标 handler 需要的 API 响应。
+4. 通过 `Bot.Run` 的真实更新分发链路发送 callback update，并捕获应用日志与 API 请求。
+5. 至少覆盖目标场景及一个相邻场景，例如缺失 `reply_to_message` 与结构完整的回调。
+
+注意：模拟器若立即返回空 `getUpdates`，应用会高速轮询并产生大量日志；输出时只截取目标 endpoint 和 handler 日志。

--- a/README.md
+++ b/README.md
@@ -20,38 +20,33 @@
 
 ## 🚀 快速开始
 
-第一次运行时会自动生成 `.env` 文件，请配置以下内容：
+复制安全的示例配置并填写 Bot Token 与 Owner Chat ID：
 
-```env
-# Telegram Bot Token
-Token=YOUR_TOKEN_ID
-
-# HTTP Server Telegram Bot Token
-HTTPToken=YOUR_TOKEN_ID
-
-# 日志等级 (可选值: DEBUG, INFO, WARN, ERROR)
-LogLevel=DEBUG/INFO/WARN/ERROR
-
-# 是否开启BotAPI debug输出(true/false)
-DebugFlag=true
-
-# API 日志等级 (可选值: DEBUG, INFO, WARN, ERROR)
-ApiLogLevel=DEBUG/INFO/WARN/ERROR
-
-# WebP 转 JPEG 的质量 (范围: 0-100)
-WebPToJPEGQuality=100
-
-# HTTP 服务器端口 (格式: :端口号)
-HTTPServerPort=:8070
-
-# 是否启用 HTTP 服务器 (true/false)
-EnableHTTPServer=false
-
-# 最大并发数  
-MaxConcurrency=5
+```bash
+cp config/config.example.yaml config/config.yaml
+chmod 600 config/config.yaml
+cd src
+go build -o ../bin/stickerDownloader .
+../bin/stickerDownloader --config ../config/config.yaml
 ```
 
-HTTP 服务器默认监听端口为：`8070`
+程序默认以 supervisor 模式启动同一二进制的 worker 子进程。worker 意外退出时会指数退避并自动重启；5 分钟内连续崩溃 5 次会暂停 15 分钟，防止 crash loop。
+
+在 `config/config.yaml` 中配置：
+
+```yaml
+telegram:
+  token: "YOUR_BOT_TOKEN"
+  http_token: "YOUR_BOT_TOKEN"
+  owner_chat_id: 123456789
+```
+
+- `owner_chat_id` 仅从 YAML 读取；设为 `0` 会禁用运维通知，但不影响自动重启。
+- Owner 会收到启动、任务级 panic、worker 崩溃、计划重启、崩溃循环和正常停止通知。
+- 向 supervisor 发送 `SIGINT` 或 `SIGTERM` 会转发给 worker 并正常停止，不会触发重启。
+- 推荐始终使用绝对路径传入 `--config`，避免工作目录变化导致读取错误。
+
+完整的通知、重启和 HTTP 配置见 `config/config.example.yaml`。HTTP 服务器默认监听端口为 `8070`。
 
 ---
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,0 +1,41 @@
+# Telegram Bot 配置 / Telegram Bot Configuration
+telegram:
+  token: "YOUR_BOT_TOKEN"
+  http_token: "YOUR_BOT_TOKEN"
+  # Owner 的私聊或群组 Chat ID；设为 0 时禁用运维通知
+  owner_chat_id: 0
+  # Telegram Bot API endpoint；通常无需修改
+  api_endpoint: "https://api.telegram.org/bot%s/%s"
+  debug: false
+
+log:
+  level: "INFO"
+  api_level: "INFO"
+
+image:
+  jpeg_quality: 100
+
+server:
+  enabled: false
+  port: ":8070"
+
+download:
+  max_concurrency: 30
+  max_retry: 3
+
+notification:
+  request_timeout: 8s
+  panic_dedup_window: 5m
+  max_stack_bytes: 8192
+
+supervisor:
+  shutdown_timeout: 10s
+  restart:
+    initial_delay: 1s
+    max_delay: 1m
+    multiplier: 2
+    jitter: 0.2
+    stable_after: 10m
+    max_restarts: 5
+    window: 5m
+    cooldown: 15m

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -18,6 +18,10 @@ image:
 server:
   enabled: false
   port: ":8070"
+  # WebUI 下载记录保留条数
+  history_size: 10
+  # WebUI 访问密码，留空时数据接口拒绝访问
+  password: ""
 
 download:
   max_concurrency: 30

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,10 @@ build: ensure_bin_dir
 	@echo "编译完成: $(FILENAME)-$(ARCH)-$(OS)-$(VERSION)"
 
 run:
-	go run ./*.go
+	go run . --config ../config/config.yaml
+
+unit_test:
+	go test ./...
 
 build_all: ensure_bin_dir
 	@echo "正在编译全平台的文件"
@@ -42,7 +45,7 @@ build_all: ensure_bin_dir
 	upx --best --lzma ../bin/$(FILENAME)-amd64-linux-$(VERSION)-upx
 	upx --best --lzma ../bin/$(FILENAME)-arm64-linux-$(VERSION)-upx
 	upx --best --lzma ../bin/$(FILENAME)-amd64-windows-$(VERSION)-upx.exe
-	upx --best --lzma ../bin/$(FILENAME)-arm64-windows-$(VERSION)-upx.exe
+	-upx --best --lzma ../bin/$(FILENAME)-arm64-windows-$(VERSION)-upx.exe || true
 	@echo "全平台编译完成"
 
 test: ensure_bin_dir

--- a/src/api/auth.go
+++ b/src/api/auth.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/swim233/StickerDownloader/config"
+)
+
+const (
+	sessionCookieName = "sd_session"
+	sessionTTL        = 7 * 24 * time.Hour
+	// loginFailureDelay slows down password brute-forcing.
+	loginFailureDelay = 400 * time.Millisecond
+)
+
+var sessionStore = struct {
+	mu     sync.Mutex
+	tokens map[string]time.Time
+}{tokens: map[string]time.Time{}}
+
+func newSessionToken() (string, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw), nil
+}
+
+func createSession() (string, error) {
+	token, err := newSessionToken()
+	if err != nil {
+		return "", err
+	}
+	now := time.Now()
+	sessionStore.mu.Lock()
+	defer sessionStore.mu.Unlock()
+	for existing, expires := range sessionStore.tokens {
+		if now.After(expires) {
+			delete(sessionStore.tokens, existing)
+		}
+	}
+	sessionStore.tokens[token] = now.Add(sessionTTL)
+	return token, nil
+}
+
+func sessionValid(token string) bool {
+	sessionStore.mu.Lock()
+	defer sessionStore.mu.Unlock()
+	expires, ok := sessionStore.tokens[token]
+	if !ok {
+		return false
+	}
+	if time.Now().After(expires) {
+		delete(sessionStore.tokens, token)
+		return false
+	}
+	return true
+}
+
+func authenticated(r *http.Request) bool {
+	cookie, err := r.Cookie(sessionCookieName)
+	return err == nil && cookie.Value != "" && sessionValid(cookie.Value)
+}
+
+func writeJSONError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}
+
+// requireAuth guards WebUI data endpoints behind a valid login session.
+func requireAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if config.WebUIPassword == "" {
+			writeJSONError(w, http.StatusForbidden, "server.password 未配置，WebUI 已禁用")
+			return
+		}
+		if !authenticated(r) {
+			writeJSONError(w, http.StatusUnauthorized, "未登录")
+			return
+		}
+		next(w, r)
+	}
+}
+
+func handleLogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "仅支持 POST")
+		return
+	}
+	if config.WebUIPassword == "" {
+		writeJSONError(w, http.StatusForbidden, "server.password 未配置，WebUI 已禁用")
+		return
+	}
+
+	var body struct {
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "请求格式错误")
+		return
+	}
+	if subtle.ConstantTimeCompare([]byte(body.Password), []byte(config.WebUIPassword)) != 1 {
+		time.Sleep(loginFailureDelay)
+		writeJSONError(w, http.StatusUnauthorized, "密码错误")
+		return
+	}
+
+	token, err := createSession()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "创建会话失败")
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    token,
+		Path:     "/",
+		MaxAge:   int(sessionTTL.Seconds()),
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	})
+	writeJSON(w, map[string]bool{"ok": true})
+}

--- a/src/api/auth_test.go
+++ b/src/api/auth_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/swim233/StickerDownloader/config"
+)
+
+func setWebUIPassword(t *testing.T, password string) {
+	t.Helper()
+	old := config.WebUIPassword
+	config.WebUIPassword = password
+	t.Cleanup(func() { config.WebUIPassword = old })
+}
+
+func doLogin(t *testing.T, password string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/login", strings.NewReader(`{"password":"`+password+`"}`))
+	rec := httptest.NewRecorder()
+	handleLogin(rec, req)
+	return rec
+}
+
+func TestLoginRejectedWithoutConfiguredPassword(t *testing.T) {
+	setWebUIPassword(t, "")
+	if rec := doLogin(t, "anything"); rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestLoginWrongPassword(t *testing.T) {
+	setWebUIPassword(t, "secret")
+	if rec := doLogin(t, "wrong"); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestLoginGetNotAllowed(t *testing.T) {
+	setWebUIPassword(t, "secret")
+	rec := httptest.NewRecorder()
+	handleLogin(rec, httptest.NewRequest(http.MethodGet, "/api/login", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestLoginSessionGrantsAccess(t *testing.T) {
+	setWebUIPassword(t, "secret")
+	loginRec := doLogin(t, "secret")
+	if loginRec.Code != http.StatusOK {
+		t.Fatalf("login status = %d, want 200", loginRec.Code)
+	}
+	cookies := loginRec.Result().Cookies()
+	if len(cookies) != 1 || cookies[0].Name != sessionCookieName || cookies[0].Value == "" {
+		t.Fatalf("cookies = %v, want one non-empty %s cookie", cookies, sessionCookieName)
+	}
+	if !cookies[0].HttpOnly {
+		t.Fatal("session cookie must be HttpOnly")
+	}
+
+	guarded := requireAuth(handleAPIStatus)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	req.AddCookie(cookies[0])
+	rec := httptest.NewRecorder()
+	guarded(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("authed status = %d, want 200", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	guarded(rec, httptest.NewRequest(http.MethodGet, "/api/status", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthed status = %d, want 401", rec.Code)
+	}
+}
+
+func TestRequireAuthDisabledWithoutPassword(t *testing.T) {
+	setWebUIPassword(t, "")
+	rec := httptest.NewRecorder()
+	requireAuth(handleAPIStatus)(rec, httptest.NewRequest(http.MethodGet, "/api/status", nil))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}

--- a/src/api/http_service.go
+++ b/src/api/http_service.go
@@ -1,25 +1,56 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
+	"time"
 
 	"github.com/swim233/StickerDownloader/config"
 	"github.com/swim233/StickerDownloader/handler"
 	"github.com/swim233/StickerDownloader/logger"
 )
 
-// StartHTTPServer starts the HTTP API server if enabled in config.
-func StartHTTPServer() {
+// RunHTTPServer starts the HTTP API server and stops it when the context is canceled.
+func RunHTTPServer(ctx context.Context) error {
 	if !config.EnableHTTPServer {
 		logger.Info("HTTP 服务器未开启")
-		return
+		<-ctx.Done()
+		return nil
 	}
 
-	logger.Info("HTTP 服务器已开启，端口: %s", config.HTTPServerPort)
-	http.HandleFunc("/stickerpack", handleStickerPack)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/stickerpack", handleStickerPack)
+	server := &http.Server{
+		Addr:              config.HTTPServerPort,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
 
-	if err := http.ListenAndServe(config.HTTPServerPort, nil); err != nil {
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer close(shutdownDone)
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), config.SupervisorShutdownTimeout)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			logger.Warn("HTTP 服务器关闭失败: %s", err)
+		}
+	}()
+
+	logger.Info("HTTP 服务器已开启，端口: %s", config.HTTPServerPort)
+	err := server.ListenAndServe()
+	if errors.Is(err, http.ErrServerClosed) && ctx.Err() != nil {
+		<-shutdownDone
+		return nil
+	}
+	return err
+}
+
+// StartHTTPServer preserves the old entry point for external callers.
+func StartHTTPServer() {
+	if err := RunHTTPServer(context.Background()); err != nil {
 		logger.Error("HTTP 服务器错误: %s", err)
 	}
 }
@@ -47,11 +78,11 @@ func handleStickerPack(w http.ResponseWriter, r *http.Request) {
 
 	if !download {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(stickerData)
+		_ = json.NewEncoder(w).Encode(stickerData)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/zip")
 	w.Header().Set("Content-Disposition", "attachment; filename="+name+".zip")
-	w.Write(stickerData)
+	_, _ = w.Write(stickerData)
 }

--- a/src/api/http_service.go
+++ b/src/api/http_service.go
@@ -20,7 +20,14 @@ func RunHTTPServer(ctx context.Context) error {
 		return nil
 	}
 
+	if config.WebUIPassword == "" {
+		logger.Warn("server.password 未配置，WebUI 数据接口将拒绝访问")
+	}
 	mux := http.NewServeMux()
+	mux.HandleFunc("/", handleIndex)
+	mux.HandleFunc("/api/login", handleLogin)
+	mux.HandleFunc("/api/status", requireAuth(handleAPIStatus))
+	mux.HandleFunc("/api/history", requireAuth(handleAPIHistory))
 	mux.HandleFunc("/stickerpack", handleStickerPack)
 	server := &http.Server{
 		Addr:              config.HTTPServerPort,

--- a/src/api/webui.go
+++ b/src/api/webui.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	_ "embed"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/swim233/StickerDownloader/lib"
+	"github.com/swim233/StickerDownloader/utils"
+)
+
+//go:embed webui/index.html
+var webuiIndexHTML []byte
+
+func handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write(webuiIndexHTML)
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func handleAPIStatus(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, utils.CurrentRuntimeStatusReport(time.Now()))
+}
+
+type historyResponse struct {
+	Capacity int                  `json:"capacity"`
+	Records  []lib.DownloadRecord `json:"records"`
+}
+
+func handleAPIHistory(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, historyResponse{
+		Capacity: utils.DownloadHistory.Capacity(),
+		Records:  utils.DownloadHistory.Recent(),
+	})
+}

--- a/src/api/webui/index.html
+++ b/src/api/webui/index.html
@@ -1,0 +1,361 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>StickerDownloader 面板</title>
+<style>
+:root {
+  --bg: #EEF3F8;
+  --card: #FFFFFF;
+  --ink: #16212B;
+  --ink-2: #5B6B7A;
+  --ink-3: #8FA1B0;
+  --accent: #2E9BD6;
+  --accent-deep: #1C6E9E;
+  --accent-soft: #E7F3FB;
+  --line: #DDE7EF;
+  --bad: #C4453A;
+  --bad-soft: #FBEBE9;
+  --ok-soft: #E8F5EC;
+  --ok: #2E7D46;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0E1621;
+    --card: #17212B;
+    --ink: #E7EDF2;
+    --ink-2: #8A9AA9;
+    --ink-3: #5F7183;
+    --accent: #4FB0E8;
+    --accent-deep: #6EC1F0;
+    --accent-soft: #1D2C3B;
+    --line: #24303C;
+    --bad: #E4766C;
+    --bad-soft: #33201F;
+    --ok-soft: #1C2F23;
+    --ok: #7CC493;
+  }
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html { -webkit-text-size-adjust: 100%; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: system-ui, -apple-system, "Segoe UI", "PingFang SC", "Noto Sans CJK SC", "Microsoft YaHei", sans-serif;
+  font-size: 15px;
+  line-height: 1.5;
+}
+.num { font-family: ui-monospace, "SF Mono", "Cascadia Mono", Consolas, monospace; font-variant-numeric: tabular-nums; }
+.wrap { max-width: 860px; margin: 0 auto; padding: 28px 16px 64px; }
+
+header { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; margin-bottom: 4px; }
+h1 { font-size: 22px; font-weight: 750; letter-spacing: -0.01em; }
+h1 .dot { color: var(--accent); }
+.sub { color: var(--ink-2); font-size: 13px; }
+.toolbar { margin-left: auto; display: flex; align-items: center; gap: 10px; }
+.updated { color: var(--ink-3); font-size: 12px; }
+button.refresh {
+  border: 1px solid var(--line); background: var(--card); color: var(--accent-deep);
+  border-radius: 8px; padding: 5px 14px; font-size: 13px; font-weight: 600; cursor: pointer;
+}
+button.refresh:hover { border-color: var(--accent); }
+button.refresh:focus-visible, a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.meta { color: var(--ink-2); font-size: 13px; margin-bottom: 20px; }
+
+.tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 10px; margin-bottom: 28px; }
+.tile { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 14px 16px 12px; }
+.tile .v { font-size: 26px; font-weight: 700; letter-spacing: -0.02em; }
+.tile .l { font-size: 12px; color: var(--ink-2); margin-top: 2px; }
+.tile .s { font-size: 12px; color: var(--ink-3); margin-top: 6px; }
+.tile.err .v { color: var(--ink); }
+.tile.err.alert .v { color: var(--bad); }
+
+.feed-head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 12px; }
+.feed-head h2 { font-size: 16px; font-weight: 700; }
+.feed-head .cap { color: var(--ink-3); font-size: 12px; }
+
+.feed { list-style: none; display: flex; flex-direction: column; gap: 10px; }
+.msg { display: flex; gap: 12px; align-items: flex-start; }
+.stk {
+  flex: none; width: 52px; height: 52px; border-radius: 14px;
+  background: var(--accent-soft);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 28px; user-select: none;
+}
+.bubble {
+  position: relative; background: var(--card); border: 1px solid var(--line);
+  border-radius: 4px 16px 16px 16px; padding: 10px 14px 9px; min-width: 0; flex: 1;
+}
+.bubble .who { font-weight: 650; font-size: 14px; }
+.bubble .who .at { color: var(--accent-deep); font-weight: 500; }
+.bubble .what { font-size: 14px; margin-top: 1px; overflow-wrap: anywhere; }
+.bubble .what b { font-weight: 650; }
+.bubble .what .set { color: var(--accent-deep); }
+.chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.chip {
+  font-size: 11.5px; color: var(--ink-2); border: 1px solid var(--line);
+  border-radius: 999px; padding: 1px 8px; white-space: nowrap;
+}
+.chip.cache { color: var(--ok); background: var(--ok-soft); border-color: transparent; }
+.chip.time { border: none; padding-left: 0; color: var(--ink-3); }
+
+.empty {
+  background: var(--card); border: 1px dashed var(--line); border-radius: 16px;
+  padding: 40px 20px; text-align: center; color: var(--ink-2); font-size: 14px;
+}
+.empty .big { font-size: 34px; margin-bottom: 8px; }
+
+.error-banner {
+  display: none; background: var(--bad-soft); color: var(--bad);
+  border-radius: 10px; padding: 8px 14px; font-size: 13px; margin-bottom: 16px;
+}
+footer { margin-top: 32px; color: var(--ink-3); font-size: 12px; }
+footer a { color: var(--accent-deep); text-decoration: none; }
+
+.login-overlay {
+  position: fixed; inset: 0; z-index: 10;
+  background: color-mix(in srgb, var(--bg) 72%, transparent);
+  backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px);
+  display: none; align-items: center; justify-content: center; padding: 16px;
+}
+.login-overlay.show { display: flex; }
+.login-card {
+  background: var(--card); border: 1px solid var(--line); border-radius: 18px;
+  padding: 28px 26px 24px; width: 100%; max-width: 320px;
+}
+.login-card .stk { margin: 0 auto 14px; }
+.login-card h2 { font-size: 17px; text-align: center; margin-bottom: 4px; }
+.login-card p { font-size: 13px; color: var(--ink-2); text-align: center; margin-bottom: 16px; }
+.login-card input {
+  width: 100%; padding: 9px 12px; font-size: 15px; color: var(--ink);
+  background: var(--bg); border: 1px solid var(--line); border-radius: 10px;
+}
+.login-card input:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; border-color: transparent; }
+.login-card button {
+  width: 100%; margin-top: 10px; padding: 9px 0; font-size: 15px; font-weight: 650;
+  color: #fff; background: var(--accent); border: none; border-radius: 10px; cursor: pointer;
+}
+.login-card button:hover { background: var(--accent-deep); }
+.login-card button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.login-card .err { color: var(--bad); font-size: 13px; text-align: center; margin-top: 10px; min-height: 1.2em; }
+
+@media (max-width: 480px) {
+  .tiles { grid-template-columns: repeat(2, 1fr); }
+  .toolbar { margin-left: 0; }
+}
+@media (prefers-reduced-motion: no-preference) {
+  .msg { animation: rise .25s ease both; }
+  @keyframes rise { from { opacity: 0; transform: translateY(4px); } }
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>StickerDownloader<span class="dot">.</span></h1>
+    <span class="sub">运行面板</span>
+    <div class="toolbar">
+      <span class="updated" id="updated"></span>
+      <button class="refresh" id="refresh" type="button">刷新</button>
+    </div>
+  </header>
+  <p class="meta" id="meta">加载中…</p>
+
+  <div class="error-banner" id="error-banner"></div>
+
+  <section class="tiles" id="tiles" aria-label="运行统计"></section>
+
+  <section aria-label="最近下载">
+    <div class="feed-head">
+      <h2>最近下载</h2>
+      <span class="cap" id="cap"></span>
+    </div>
+    <ol class="feed" id="feed"></ol>
+    <div class="empty" id="empty" hidden>
+      <div class="big">📭</div>
+      还没有下载记录 — 给机器人发送一个贴纸，记录会出现在这里
+    </div>
+  </section>
+
+  <footer>数据每 10 秒自动刷新 · HTTP 接口：<a href="api/status">api/status</a> · <a href="api/history">api/history</a></footer>
+</div>
+
+<div class="login-overlay" id="login-overlay">
+  <form class="login-card" id="login-form">
+    <div class="stk">🔐</div>
+    <h2>StickerDownloader</h2>
+    <p>输入访问密码查看运行面板</p>
+    <input type="password" id="login-password" placeholder="访问密码" autocomplete="current-password" aria-label="访问密码">
+    <button type="submit">登录</button>
+    <div class="err" id="login-error"></div>
+  </form>
+</div>
+
+<script>
+"use strict";
+const $ = id => document.getElementById(id);
+
+function fmtBytes(n) {
+  if (!n) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let i = 0;
+  while (n >= 1024 && i < units.length - 1) { n /= 1024; i++; }
+  return (i === 0 ? n : n.toFixed(1)) + " " + units[i];
+}
+function fmtUptime(sec) {
+  if (sec < 0) sec = 0;
+  const d = Math.floor(sec / 86400), h = Math.floor(sec % 86400 / 3600), m = Math.floor(sec % 3600 / 60);
+  if (d > 0) return d + " 天 " + h + " 小时";
+  if (h > 0) return h + " 小时 " + m + " 分钟";
+  return m + " 分钟";
+}
+function fmtTime(iso) {
+  const t = new Date(iso), now = new Date();
+  const diff = (now - t) / 1000;
+  if (diff < 60) return "刚刚";
+  if (diff < 3600) return Math.floor(diff / 60) + " 分钟前";
+  const sameDay = t.toDateString() === now.toDateString();
+  const hm = t.toTimeString().slice(0, 5);
+  if (sameDay) return hm;
+  return (t.getMonth() + 1) + "月" + t.getDate() + "日 " + hm;
+}
+function el(tag, cls, text) {
+  const e = document.createElement(tag);
+  if (cls) e.className = cls;
+  if (text !== undefined) e.textContent = text;
+  return e;
+}
+
+function tile(value, label, sub, cls) {
+  const t = el("div", "tile" + (cls ? " " + cls : ""));
+  t.append(Object.assign(el("div", "v num", value)), el("div", "l", label));
+  if (sub) t.append(el("div", "s", sub));
+  return t;
+}
+
+function renderStatus(s) {
+  $("meta").textContent = "启动于 " + new Date(s.start_time).toLocaleString("zh-CN", { hour12: false }) +
+    " · 已运行 " + fmtUptime(s.uptime_seconds);
+  const tiles = $("tiles");
+  tiles.replaceChildren(
+    tile(String(s.single_download), "已下载贴纸", "单个贴纸（Bot）"),
+    tile(String(s.pack_download), "已下载贴纸包", "Bot 请求"),
+    tile(String(s.http_pack_download), "HTTP 贴纸包", "HTTP 接口请求"),
+    tile(s.cache_hit_rate.toFixed(1) + "%", "缓存命中率", "命中 " + s.cache_hits + " 次"),
+    tile(String(s.total_errors), "错误",
+      "panic " + s.panic_errors + " · 请求 " + s.request_errors + " · 下载 " + s.download_errors + " · 通知 " + s.notification_errors,
+      s.total_errors > 0 ? "err alert" : "err")
+  );
+}
+
+function stickerFace(r) {
+  if (r.kind === "single" && r.sticker_emoji) return r.sticker_emoji;
+  if (r.kind === "pack") return "📦";
+  return "🖼️";
+}
+function whoText(r) {
+  if (r.source === "http") return r.display_name || "HTTP API";
+  return r.display_name || (r.user_id ? "用户 " + r.user_id : "未知用户");
+}
+
+function renderHistory(h) {
+  $("cap").textContent = "保留最近 " + h.capacity + " 条";
+  const feed = $("feed");
+  feed.replaceChildren();
+  const records = h.records || [];
+  $("empty").hidden = records.length > 0;
+  for (const r of records) {
+    const li = el("li", "msg");
+    li.append(el("div", "stk", stickerFace(r)));
+    const bubble = el("div", "bubble");
+
+    const who = el("div", "who", whoText(r));
+    if (r.user_name) who.append(" ", Object.assign(el("span", "at", "@" + r.user_name)));
+    bubble.append(who);
+
+    const what = el("div", "what");
+    what.append(r.kind === "pack" ? "下载了贴纸包 " : "下载了单个贴纸 ");
+    const setLabel = r.set_title || r.set_name;
+    if (setLabel) {
+      const b = el("b", "set", setLabel);
+      what.append(b);
+      if (r.set_title && r.set_name && r.set_title !== r.set_name) what.append(" (" + r.set_name + ")");
+    } else {
+      what.append("（无贴纸包）");
+    }
+    bubble.append(what);
+
+    const chips = el("div", "chips");
+    chips.append(el("span", "chip", r.format));
+    if (r.kind === "pack") chips.append(el("span", "chip", r.file_count + " 张"));
+    if (r.file_size) chips.append(el("span", "chip", fmtBytes(r.file_size)));
+    if (r.cache_hit) chips.append(el("span", "chip cache", "缓存命中"));
+    if (r.source === "http") chips.append(el("span", "chip", "HTTP"));
+    chips.append(el("span", "chip time", fmtTime(r.time)));
+    bubble.append(chips);
+
+    li.append(bubble);
+    feed.append(li);
+  }
+}
+
+function showLogin(show) {
+  $("login-overlay").classList.toggle("show", show);
+  if (show) $("login-password").focus();
+}
+
+async function refresh() {
+  const banner = $("error-banner");
+  try {
+    const [statusResp, historyResp] = await Promise.all([fetch("api/status"), fetch("api/history")]);
+    if (statusResp.status === 401 || historyResp.status === 401) {
+      showLogin(true);
+      return;
+    }
+    if (statusResp.status === 403) {
+      const body = await statusResp.json().catch(() => ({}));
+      throw new Error(body.error || "WebUI 已禁用");
+    }
+    if (!statusResp.ok || !historyResp.ok) throw new Error("接口返回 " + statusResp.status + "/" + historyResp.status);
+    renderStatus(await statusResp.json());
+    renderHistory(await historyResp.json());
+    showLogin(false);
+    banner.style.display = "none";
+    $("updated").textContent = "更新于 " + new Date().toTimeString().slice(0, 8);
+  } catch (err) {
+    banner.textContent = "获取数据失败：" + err.message + "，将在下次刷新时重试";
+    banner.style.display = "block";
+  }
+}
+
+$("login-form").addEventListener("submit", async e => {
+  e.preventDefault();
+  const errorLine = $("login-error");
+  errorLine.textContent = "";
+  try {
+    const resp = await fetch("api/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password: $("login-password").value })
+    });
+    if (!resp.ok) {
+      const body = await resp.json().catch(() => ({}));
+      errorLine.textContent = body.error || "登录失败（" + resp.status + "）";
+      return;
+    }
+    $("login-password").value = "";
+    showLogin(false);
+    refresh();
+  } catch (err) {
+    errorLine.textContent = "无法连接服务器：" + err.message;
+  }
+});
+
+$("refresh").addEventListener("click", refresh);
+setInterval(() => { if (!document.hidden) refresh(); }, 10000);
+refresh();
+</script>
+</body>
+</html>

--- a/src/api/webui_test.go
+++ b/src/api/webui_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/swim233/StickerDownloader/lib"
+	"github.com/swim233/StickerDownloader/utils"
+)
+
+func TestHandleIndexServesWebUI(t *testing.T) {
+	rec := httptest.NewRecorder()
+	handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("Content-Type = %q, want text/html", ct)
+	}
+	if !strings.Contains(rec.Body.String(), "最近下载") {
+		t.Fatal("index page missing history section")
+	}
+}
+
+func TestHandleIndexRejectsOtherPaths(t *testing.T) {
+	rec := httptest.NewRecorder()
+	handleIndex(rec, httptest.NewRequest(http.MethodGet, "/nope", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandleAPIHistoryReturnsRecords(t *testing.T) {
+	utils.DownloadHistory.Add(lib.DownloadRecord{
+		Source:   lib.DownloadSourceBot,
+		Kind:     lib.DownloadKindPack,
+		UserName: "tester",
+		SetName:  "test_set",
+		Format:   "webp",
+	})
+
+	rec := httptest.NewRecorder()
+	handleAPIHistory(rec, httptest.NewRequest(http.MethodGet, "/api/history", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp historyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Capacity <= 0 {
+		t.Fatalf("capacity = %d, want > 0", resp.Capacity)
+	}
+	if len(resp.Records) == 0 || resp.Records[0].SetName != "test_set" {
+		t.Fatalf("records = %+v, want newest record test_set first", resp.Records)
+	}
+}
+
+func TestHandleAPIStatusReturnsJSON(t *testing.T) {
+	rec := httptest.NewRecorder()
+	handleAPIStatus(rec, httptest.NewRequest(http.MethodGet, "/api/status", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var report utils.RuntimeStatusReport
+	if err := json.Unmarshal(rec.Body.Bytes(), &report); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+}

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -1,17 +1,24 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/spf13/viper"
 )
 
+const DefaultTelegramAPIEndpoint = "https://api.telegram.org/bot%s/%s"
+
 var (
 	// Telegram Bot
-	BotToken  string
-	HTTPToken string
-	DebugFlag bool
+	BotToken            string
+	HTTPToken           string
+	OwnerChatID         int64
+	TelegramAPIEndpoint string
+	DebugFlag           bool
 
 	// Log
 	LogLevel    string
@@ -29,94 +36,266 @@ var (
 
 	// Retry
 	MaxRetry int
+
+	// Operational notifications
+	NotificationRequestTimeout time.Duration
+	PanicDedupWindow           time.Duration
+	MaxStackBytes              int
+
+	// Process supervision
+	SupervisorShutdownTimeout time.Duration
+	RestartInitialDelay       time.Duration
+	RestartMaxDelay           time.Duration
+	RestartMultiplier         float64
+	RestartJitter             float64
+	RestartStableAfter        time.Duration
+	RestartMaxRestarts        int
+	RestartWindow             time.Duration
+	RestartCooldown           time.Duration
 )
 
-// InitConfig loads configuration from config.yaml and environment variables.
-func InitConfig() {
-	viper.SetConfigName("config")
-	viper.SetConfigType("yaml")
-	viper.AddConfigPath("../config")  // ../config/ (从 src/ 运行时)
-	viper.AddConfigPath(".")          // 当前目录 (从项目根目录运行时)
-
-	// Defaults
-	viper.SetDefault("telegram.debug", false)
-	viper.SetDefault("log.level", "INFO")
-	viper.SetDefault("log.api_level", "INFO")
-	viper.SetDefault("image.jpeg_quality", 100)
-	viper.SetDefault("server.enabled", false)
-	viper.SetDefault("server.port", ":8070")
-	viper.SetDefault("download.max_concurrency", 30)
-	viper.SetDefault("download.max_retry", 3)
-
-	// Allow environment variable overrides
-	viper.AutomaticEnv()
-
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			createDefaultYAMLConfig()
-			fmt.Println("config/config.yaml 已创建，请填写配置后重新启动。")
-			fmt.Println("config/config.yaml has been created. Please fill in your settings and restart.")
-			os.Exit(1)
-		}
-		fmt.Printf("读取配置文件失败: %v\n", err)
-		os.Exit(1)
-	}
-
-	BotToken = viper.GetString("telegram.token")
-	HTTPToken = viper.GetString("telegram.http_token")
-	DebugFlag = viper.GetBool("telegram.debug")
-	LogLevel = viper.GetString("log.level")
-	ApiLogLevel = viper.GetString("log.api_level")
-	JpegQuality = viper.GetInt("image.jpeg_quality")
-	EnableHTTPServer = viper.GetBool("server.enabled")
-	HTTPServerPort = viper.GetString("server.port")
-	MaxConcurrency = viper.GetInt("download.max_concurrency")
-	MaxRetry = viper.GetInt("download.max_retry")
+type Settings struct {
+	BotToken            string
+	HTTPToken           string
+	OwnerChatID         int64
+	TelegramAPIEndpoint string
+	DebugFlag           bool
+	LogLevel            string
+	APILevel            string
+	JPEGQuality         int
+	EnableHTTPServer    bool
+	HTTPServerPort      string
+	MaxConcurrency      int
+	MaxRetry            int
+	Notification        NotificationSettings
+	Supervisor          SupervisorSettings
 }
 
-func createDefaultYAMLConfig() {
-	content := `# Telegram Bot 配置 / Telegram Bot Configuration
-telegram:
-  # Bot Token (从 @BotFather 获取 / Get from @BotFather)
-  token: "YOUR_TOKEN_HERE"
-  # HTTP 服务使用的 Token，可与上面相同 / Token for HTTP service, can be the same
-  http_token: "YOUR_TOKEN_HERE"
-  # 是否开启 BotAPI debug 输出 / Enable BotAPI debug output
+type NotificationSettings struct {
+	RequestTimeout time.Duration
+	PanicDedup     time.Duration
+	MaxStackBytes  int
+}
+
+type SupervisorSettings struct {
+	ShutdownTimeout time.Duration
+	Restart         RestartSettings
+}
+
+type RestartSettings struct {
+	InitialDelay time.Duration
+	MaxDelay     time.Duration
+	Multiplier   float64
+	Jitter       float64
+	StableAfter  time.Duration
+	MaxRestarts  int
+	Window       time.Duration
+	Cooldown     time.Duration
+}
+
+// Load reads and validates a configuration without mutating package globals.
+func Load(configPath string) (Settings, string, error) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	setDefaults(v)
+
+	if configPath != "" {
+		absolutePath, err := filepath.Abs(configPath)
+		if err != nil {
+			return Settings{}, "", fmt.Errorf("解析配置路径: %w", err)
+		}
+		v.SetConfigFile(absolutePath)
+	} else {
+		v.SetConfigName("config")
+		v.AddConfigPath("../config")
+		v.AddConfigPath(".")
+	}
+
+	if err := v.ReadInConfig(); err != nil {
+		return Settings{}, "", fmt.Errorf("读取配置文件: %w", err)
+	}
+
+	usedPath, err := filepath.Abs(v.ConfigFileUsed())
+	if err != nil {
+		return Settings{}, "", fmt.Errorf("解析配置文件路径: %w", err)
+	}
+
+	settings := Settings{
+		BotToken:            v.GetString("telegram.token"),
+		HTTPToken:           v.GetString("telegram.http_token"),
+		OwnerChatID:         v.GetInt64("telegram.owner_chat_id"),
+		TelegramAPIEndpoint: v.GetString("telegram.api_endpoint"),
+		DebugFlag:           v.GetBool("telegram.debug"),
+		LogLevel:            v.GetString("log.level"),
+		APILevel:            v.GetString("log.api_level"),
+		JPEGQuality:         v.GetInt("image.jpeg_quality"),
+		EnableHTTPServer:    v.GetBool("server.enabled"),
+		HTTPServerPort:      v.GetString("server.port"),
+		MaxConcurrency:      v.GetInt("download.max_concurrency"),
+		MaxRetry:            v.GetInt("download.max_retry"),
+		Notification: NotificationSettings{
+			RequestTimeout: v.GetDuration("notification.request_timeout"),
+			PanicDedup:     v.GetDuration("notification.panic_dedup_window"),
+			MaxStackBytes:  v.GetInt("notification.max_stack_bytes"),
+		},
+		Supervisor: SupervisorSettings{
+			ShutdownTimeout: v.GetDuration("supervisor.shutdown_timeout"),
+			Restart: RestartSettings{
+				InitialDelay: v.GetDuration("supervisor.restart.initial_delay"),
+				MaxDelay:     v.GetDuration("supervisor.restart.max_delay"),
+				Multiplier:   v.GetFloat64("supervisor.restart.multiplier"),
+				Jitter:       v.GetFloat64("supervisor.restart.jitter"),
+				StableAfter:  v.GetDuration("supervisor.restart.stable_after"),
+				MaxRestarts:  v.GetInt("supervisor.restart.max_restarts"),
+				Window:       v.GetDuration("supervisor.restart.window"),
+				Cooldown:     v.GetDuration("supervisor.restart.cooldown"),
+			},
+		},
+	}
+	if err := validate(settings); err != nil {
+		return Settings{}, usedPath, err
+	}
+	return settings, usedPath, nil
+}
+
+func setDefaults(v *viper.Viper) {
+	v.SetDefault("telegram.api_endpoint", DefaultTelegramAPIEndpoint)
+	v.SetDefault("telegram.debug", false)
+	v.SetDefault("log.level", "INFO")
+	v.SetDefault("log.api_level", "INFO")
+	v.SetDefault("image.jpeg_quality", 100)
+	v.SetDefault("server.enabled", false)
+	v.SetDefault("server.port", ":8070")
+	v.SetDefault("download.max_concurrency", 30)
+	v.SetDefault("download.max_retry", 3)
+	v.SetDefault("notification.request_timeout", "8s")
+	v.SetDefault("notification.panic_dedup_window", "5m")
+	v.SetDefault("notification.max_stack_bytes", 8192)
+	v.SetDefault("supervisor.shutdown_timeout", "10s")
+	v.SetDefault("supervisor.restart.initial_delay", "1s")
+	v.SetDefault("supervisor.restart.max_delay", "1m")
+	v.SetDefault("supervisor.restart.multiplier", 2.0)
+	v.SetDefault("supervisor.restart.jitter", 0.2)
+	v.SetDefault("supervisor.restart.stable_after", "10m")
+	v.SetDefault("supervisor.restart.max_restarts", 5)
+	v.SetDefault("supervisor.restart.window", "5m")
+	v.SetDefault("supervisor.restart.cooldown", "15m")
+}
+
+func validate(s Settings) error {
+	var validationErrors []error
+	if s.BotToken == "" || s.BotToken == "YOUR_TOKEN_HERE" || s.BotToken == "YOUR_BOT_TOKEN" {
+		validationErrors = append(validationErrors, errors.New("telegram.token 未配置"))
+	}
+	if s.HTTPToken == "" {
+		validationErrors = append(validationErrors, errors.New("telegram.http_token 未配置"))
+	}
+	if s.TelegramAPIEndpoint == "" {
+		validationErrors = append(validationErrors, errors.New("telegram.api_endpoint 不能为空"))
+	}
+	if s.JPEGQuality < 0 || s.JPEGQuality > 100 {
+		validationErrors = append(validationErrors, errors.New("image.jpeg_quality 必须在 0 到 100 之间"))
+	}
+	if s.MaxConcurrency <= 0 {
+		validationErrors = append(validationErrors, errors.New("download.max_concurrency 必须大于 0"))
+	}
+	if s.MaxRetry <= 0 {
+		validationErrors = append(validationErrors, errors.New("download.max_retry 必须大于 0"))
+	}
+	if s.Notification.RequestTimeout <= 0 || s.Notification.PanicDedup <= 0 || s.Notification.MaxStackBytes <= 0 {
+		validationErrors = append(validationErrors, errors.New("notification 配置必须大于 0"))
+	}
+	r := s.Supervisor.Restart
+	if s.Supervisor.ShutdownTimeout <= 0 || r.InitialDelay <= 0 || r.MaxDelay < r.InitialDelay || r.Multiplier < 1 || r.Jitter < 0 || r.Jitter > 1 || r.StableAfter <= 0 || r.MaxRestarts <= 0 || r.Window <= 0 || r.Cooldown <= 0 {
+		validationErrors = append(validationErrors, errors.New("supervisor 配置无效"))
+	}
+	return errors.Join(validationErrors...)
+}
+
+// Apply publishes validated settings for existing packages that use config globals.
+func Apply(s Settings) {
+	BotToken = s.BotToken
+	HTTPToken = s.HTTPToken
+	OwnerChatID = s.OwnerChatID
+	TelegramAPIEndpoint = s.TelegramAPIEndpoint
+	DebugFlag = s.DebugFlag
+	LogLevel = s.LogLevel
+	ApiLogLevel = s.APILevel
+	JpegQuality = s.JPEGQuality
+	EnableHTTPServer = s.EnableHTTPServer
+	HTTPServerPort = s.HTTPServerPort
+	MaxConcurrency = s.MaxConcurrency
+	MaxRetry = s.MaxRetry
+	NotificationRequestTimeout = s.Notification.RequestTimeout
+	PanicDedupWindow = s.Notification.PanicDedup
+	MaxStackBytes = s.Notification.MaxStackBytes
+	SupervisorShutdownTimeout = s.Supervisor.ShutdownTimeout
+	RestartInitialDelay = s.Supervisor.Restart.InitialDelay
+	RestartMaxDelay = s.Supervisor.Restart.MaxDelay
+	RestartMultiplier = s.Supervisor.Restart.Multiplier
+	RestartJitter = s.Supervisor.Restart.Jitter
+	RestartStableAfter = s.Supervisor.Restart.StableAfter
+	RestartMaxRestarts = s.Supervisor.Restart.MaxRestarts
+	RestartWindow = s.Supervisor.Restart.Window
+	RestartCooldown = s.Supervisor.Restart.Cooldown
+}
+
+// InitConfig loads and applies configuration for compatibility with existing callers.
+func InitConfig(configPath ...string) error {
+	path := ""
+	if len(configPath) > 0 {
+		path = configPath[0]
+	}
+	settings, _, err := Load(path)
+	if err != nil {
+		return err
+	}
+	Apply(settings)
+	return nil
+}
+
+// WriteExampleConfig writes a safe placeholder configuration when explicitly requested.
+func WriteExampleConfig(path string) error {
+	const content = `telegram:
+  token: "YOUR_BOT_TOKEN"
+  http_token: "YOUR_BOT_TOKEN"
+  owner_chat_id: 0
   debug: false
 
-# 日志配置 / Log Configuration
 log:
-  # 日志等级 / Log level (DEBUG, INFO, WARN, ERROR)
   level: "INFO"
-  # Bot API 日志等级 / Bot API log level (DEBUG, INFO, WARN, ERROR)
   api_level: "INFO"
 
-# 图片转换配置 / Image Conversion
 image:
-  # WebP 转 JPEG 的质量 / WebP to JPEG quality (0-100)
   jpeg_quality: 100
 
-# HTTP 服务器配置 / HTTP Server Configuration
 server:
-  # 是否启用 HTTP 服务器 / Enable HTTP server
   enabled: false
-  # 监听端口 / Listen port
   port: ":8070"
 
-# 下载配置 / Download Configuration
 download:
-  # 最大并发下载数 / Max concurrent downloads
   max_concurrency: 30
-  # 最大重试次数 / Max retry count
   max_retry: 3
+
+notification:
+  request_timeout: 8s
+  panic_dedup_window: 5m
+  max_stack_bytes: 8192
+
+supervisor:
+  shutdown_timeout: 10s
+  restart:
+    initial_delay: 1s
+    max_delay: 1m
+    multiplier: 2
+    jitter: 0.2
+    stable_after: 10m
+    max_restarts: 5
+    window: 5m
+    cooldown: 15m
 `
-	// 尝试多个可能的路径写入
-	for _, dir := range []string{"../config", "."} {
-		os.MkdirAll(dir, 0755)
-		path := dir + "/config.yaml"
-		if err := os.WriteFile(path, []byte(content), 0644); err == nil {
-			fmt.Printf("配置文件已写入: %s\n", path)
-			return
-		}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
 	}
+	return os.WriteFile(path, []byte(content), 0600)
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -31,6 +31,10 @@ var (
 	EnableHTTPServer bool
 	HTTPServerPort   string
 
+	// WebUI
+	DownloadHistorySize int
+	WebUIPassword       string
+
 	// Concurrency
 	MaxConcurrency int
 
@@ -65,6 +69,8 @@ type Settings struct {
 	JPEGQuality         int
 	EnableHTTPServer    bool
 	HTTPServerPort      string
+	DownloadHistorySize int
+	WebUIPassword       string
 	MaxConcurrency      int
 	MaxRetry            int
 	Notification        NotificationSettings
@@ -131,6 +137,8 @@ func Load(configPath string) (Settings, string, error) {
 		JPEGQuality:         v.GetInt("image.jpeg_quality"),
 		EnableHTTPServer:    v.GetBool("server.enabled"),
 		HTTPServerPort:      v.GetString("server.port"),
+		DownloadHistorySize: v.GetInt("server.history_size"),
+		WebUIPassword:       v.GetString("server.password"),
 		MaxConcurrency:      v.GetInt("download.max_concurrency"),
 		MaxRetry:            v.GetInt("download.max_retry"),
 		Notification: NotificationSettings{
@@ -166,6 +174,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("image.jpeg_quality", 100)
 	v.SetDefault("server.enabled", false)
 	v.SetDefault("server.port", ":8070")
+	v.SetDefault("server.history_size", 10)
 	v.SetDefault("download.max_concurrency", 30)
 	v.SetDefault("download.max_retry", 3)
 	v.SetDefault("notification.request_timeout", "8s")
@@ -196,6 +205,9 @@ func validate(s Settings) error {
 	if s.JPEGQuality < 0 || s.JPEGQuality > 100 {
 		validationErrors = append(validationErrors, errors.New("image.jpeg_quality 必须在 0 到 100 之间"))
 	}
+	if s.DownloadHistorySize <= 0 {
+		validationErrors = append(validationErrors, errors.New("server.history_size 必须大于 0"))
+	}
 	if s.MaxConcurrency <= 0 {
 		validationErrors = append(validationErrors, errors.New("download.max_concurrency 必须大于 0"))
 	}
@@ -224,6 +236,8 @@ func Apply(s Settings) {
 	JpegQuality = s.JPEGQuality
 	EnableHTTPServer = s.EnableHTTPServer
 	HTTPServerPort = s.HTTPServerPort
+	DownloadHistorySize = s.DownloadHistorySize
+	WebUIPassword = s.WebUIPassword
 	MaxConcurrency = s.MaxConcurrency
 	MaxRetry = s.MaxRetry
 	NotificationRequestTimeout = s.Notification.RequestTimeout
@@ -272,6 +286,8 @@ image:
 server:
   enabled: false
   port: ":8070"
+  history_size: 10
+  password: ""
 
 download:
   max_concurrency: 30

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadOwnerChatIDFromYAML(t *testing.T) {
+	path := writeTestConfig(t, "123456789")
+	settings, usedPath, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settings.OwnerChatID != 123456789 {
+		t.Fatalf("owner_chat_id = %d", settings.OwnerChatID)
+	}
+	if !filepath.IsAbs(usedPath) {
+		t.Fatalf("config path is not absolute: %s", usedPath)
+	}
+}
+
+func TestOwnerChatIDIsNotReadFromEnvironment(t *testing.T) {
+	t.Setenv("TELEGRAM_OWNER_CHAT_ID", "999")
+	path := writeTestConfig(t, "42")
+	settings, _, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settings.OwnerChatID != 42 {
+		t.Fatalf("owner_chat_id = %d", settings.OwnerChatID)
+	}
+}
+
+func TestOwnerChatIDZeroDisablesNotifications(t *testing.T) {
+	path := writeTestConfig(t, "0")
+	settings, _, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settings.OwnerChatID != 0 {
+		t.Fatalf("owner_chat_id = %d", settings.OwnerChatID)
+	}
+}
+
+func TestInvalidConcurrencyFailsValidation(t *testing.T) {
+	path := writeTestConfig(t, "1")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = []byte(string(data) + "\ndownload:\n  max_concurrency: 0\n  max_retry: 3\n")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Load(path); err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func writeTestConfig(t *testing.T, owner string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := "telegram:\n" +
+		"  token: fake-token\n" +
+		"  http_token: fake-token\n" +
+		"  owner_chat_id: " + owner + "\n" +
+		"download:\n" +
+		"  max_concurrency: 2\n" +
+		"  max_retry: 1\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/src/core/bot.go
+++ b/src/core/bot.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -16,14 +17,16 @@ var (
 )
 
 // InitBot creates and configures the Telegram bot instances.
-func InitBot() {
+func InitBot() error {
 	var err error
+	newBot := func(token string) (*tgbotapi.BotAPI, error) {
+		return tgbotapi.NewBotAPIWithAPIEndpoint(token, config.TelegramAPIEndpoint)
+	}
 
 	// Initialize HTTP bot (always needed)
-	HTTPBot, err = tgbotapi.NewBotAPI(config.HTTPToken)
+	HTTPBot, err = newBot(config.HTTPToken)
 	if err != nil {
-		logger.Error("实例化 HTTP BotAPI 失败: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("实例化 HTTP BotAPI: %w", err)
 	}
 	HTTPBot.Debug = config.DebugFlag
 
@@ -31,10 +34,9 @@ func InitBot() {
 	if config.HTTPToken == config.BotToken {
 		Bot = HTTPBot
 	} else {
-		Bot, err = tgbotapi.NewBotAPI(config.BotToken)
+		Bot, err = newBot(config.BotToken)
 		if err != nil {
-			logger.Error("实例化 BotAPI 失败: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("实例化 BotAPI: %w", err)
 		}
 		Bot.Debug = config.DebugFlag
 	}
@@ -47,14 +49,14 @@ func InitBot() {
 	if proxy := fetchProxy(); proxy != "" {
 		proxyURL, err := url.Parse(proxy)
 		if err != nil {
-			logger.Error("解析代理 URL 失败: %s", proxy)
-			return
+			return fmt.Errorf("解析代理 URL: %w", err)
 		}
 		Bot.Client = &http.Client{
 			Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)},
 		}
-		logger.Info("使用代理: %s", proxy)
+		logger.Info("使用代理")
 	}
+	return nil
 }
 
 func fetchProxy() string {

--- a/src/db/download_record_db.go
+++ b/src/db/download_record_db.go
@@ -1,0 +1,89 @@
+package db
+
+import (
+	"time"
+
+	"github.com/swim233/StickerDownloader/lib"
+)
+
+// DownloadRecordData persists WebUI download-history rows across restarts.
+type DownloadRecordData struct {
+	ID            uint `gorm:"primaryKey"`
+	Time          time.Time
+	Source        string
+	Kind          string
+	UserID        int64
+	UserName      string
+	DisplayName   string
+	SetName       string
+	SetTitle      string
+	StickerFileID string
+	StickerEmoji  string
+	Format        string
+	FileCount     int
+	FileSize      int64
+	CacheHit      bool
+}
+
+func (d DownloadRecordData) toLib() lib.DownloadRecord {
+	return lib.DownloadRecord{
+		Time:          d.Time,
+		Source:        d.Source,
+		Kind:          d.Kind,
+		UserID:        d.UserID,
+		UserName:      d.UserName,
+		DisplayName:   d.DisplayName,
+		SetName:       d.SetName,
+		SetTitle:      d.SetTitle,
+		StickerFileID: d.StickerFileID,
+		StickerEmoji:  d.StickerEmoji,
+		Format:        d.Format,
+		FileCount:     d.FileCount,
+		FileSize:      d.FileSize,
+		CacheHit:      d.CacheHit,
+	}
+}
+
+// SaveDownloadRecord appends a record and prunes rows beyond the newest keep.
+func SaveDownloadRecord(record lib.DownloadRecord, keep int) error {
+	row := DownloadRecordData{
+		Time:          record.Time,
+		Source:        record.Source,
+		Kind:          record.Kind,
+		UserID:        record.UserID,
+		UserName:      record.UserName,
+		DisplayName:   record.DisplayName,
+		SetName:       record.SetName,
+		SetTitle:      record.SetTitle,
+		StickerFileID: record.StickerFileID,
+		StickerEmoji:  record.StickerEmoji,
+		Format:        record.Format,
+		FileCount:     record.FileCount,
+		FileSize:      record.FileSize,
+		CacheHit:      record.CacheHit,
+	}
+	if err := DB.Create(&row).Error; err != nil {
+		return err
+	}
+	if keep <= 0 {
+		keep = lib.DefaultDownloadHistorySize
+	}
+	newest := DB.Model(&DownloadRecordData{}).Select("id").Order("id DESC").Limit(keep)
+	return DB.Where("id NOT IN (?)", newest).Delete(&DownloadRecordData{}).Error
+}
+
+// LoadRecentDownloadRecords returns up to n persisted records, oldest first.
+func LoadRecentDownloadRecords(n int) ([]lib.DownloadRecord, error) {
+	if n <= 0 {
+		n = lib.DefaultDownloadHistorySize
+	}
+	var rows []DownloadRecordData
+	if err := DB.Order("id DESC").Limit(n).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	records := make([]lib.DownloadRecord, len(rows))
+	for i, row := range rows {
+		records[len(rows)-1-i] = row.toLib()
+	}
+	return records, nil
+}

--- a/src/db/download_record_db_test.go
+++ b/src/db/download_record_db_test.go
@@ -1,0 +1,96 @@
+package db
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"github.com/swim233/StickerDownloader/lib"
+	"gorm.io/gorm"
+)
+
+func setupTestDB(t *testing.T) {
+	t.Helper()
+	old := DB
+	database, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "test.db")), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	if err := database.AutoMigrate(&DownloadRecordData{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	DB = database
+	t.Cleanup(func() { DB = old })
+}
+
+func TestSaveDownloadRecordPrunesToKeep(t *testing.T) {
+	setupTestDB(t)
+	for i := range 12 {
+		record := lib.DownloadRecord{
+			Time:    time.Unix(int64(i), 0),
+			Source:  lib.DownloadSourceBot,
+			Kind:    lib.DownloadKindPack,
+			SetName: fmt.Sprintf("set%d", i),
+			Format:  "webp",
+		}
+		if err := SaveDownloadRecord(record, 10); err != nil {
+			t.Fatalf("save %d: %v", i, err)
+		}
+	}
+
+	var count int64
+	if err := DB.Model(&DownloadRecordData{}).Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 10 {
+		t.Fatalf("count = %d, want 10", count)
+	}
+
+	records, err := LoadRecentDownloadRecords(10)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(records) != 10 {
+		t.Fatalf("len = %d, want 10", len(records))
+	}
+	if records[0].SetName != "set2" || records[9].SetName != "set11" {
+		t.Fatalf("records span %s..%s, want set2..set11 oldest first", records[0].SetName, records[9].SetName)
+	}
+}
+
+func TestDownloadRecordRoundTrip(t *testing.T) {
+	setupTestDB(t)
+	want := lib.DownloadRecord{
+		Time:          time.Unix(1700000000, 0).UTC(),
+		Source:        lib.DownloadSourceBot,
+		Kind:          lib.DownloadKindSingle,
+		UserID:        42,
+		UserName:      "tester",
+		DisplayName:   "Test User",
+		SetName:       "cats",
+		SetTitle:      "Cats!",
+		StickerFileID: "file-id-1",
+		StickerEmoji:  "😺",
+		Format:        "png",
+		FileCount:     1,
+		FileSize:      2048,
+		CacheHit:      true,
+	}
+	if err := SaveDownloadRecord(want, 10); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	records, err := LoadRecentDownloadRecords(10)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len = %d, want 1", len(records))
+	}
+	got := records[0]
+	got.Time = got.Time.UTC()
+	if got != want {
+		t.Fatalf("round trip mismatch:\ngot  %+v\nwant %+v", got, want)
+	}
+}

--- a/src/db/user_db.go
+++ b/src/db/user_db.go
@@ -44,15 +44,19 @@ type StickerData struct {
 var DB *gorm.DB
 
 // 初始化数据库
-func InitDB() {
-	os.MkdirAll("db", 0700)
-	db, err := gorm.Open(sqlite.Open("db/data.db"), &gorm.Config{})
-	if err != nil {
-		fmt.Printf("数据库初始化失败: %v\n", err)
-		os.Exit(1)
+func InitDB() error {
+	if err := os.MkdirAll("db", 0700); err != nil {
+		return fmt.Errorf("创建数据库目录: %w", err)
 	}
-	DB = db
-	DB.AutoMigrate(&UserData{}, &StickerData{})
+	database, err := gorm.Open(sqlite.Open("db/data.db"), &gorm.Config{})
+	if err != nil {
+		return fmt.Errorf("数据库初始化: %w", err)
+	}
+	DB = database
+	if err := DB.AutoMigrate(&UserData{}, &StickerData{}); err != nil {
+		return fmt.Errorf("数据库迁移: %w", err)
+	}
+	return nil
 }
 
 // 初始化用户数据

--- a/src/db/user_db.go
+++ b/src/db/user_db.go
@@ -53,7 +53,7 @@ func InitDB() error {
 		return fmt.Errorf("数据库初始化: %w", err)
 	}
 	DB = database
-	if err := DB.AutoMigrate(&UserData{}, &StickerData{}); err != nil {
+	if err := DB.AutoMigrate(&UserData{}, &StickerData{}, &DownloadRecordData{}); err != nil {
 		return fmt.Errorf("数据库迁移: %w", err)
 	}
 	return nil

--- a/src/handler/message_send_handler.go
+++ b/src/handler/message_send_handler.go
@@ -13,6 +13,7 @@ import (
 	db "github.com/swim233/StickerDownloader/db"
 	"github.com/swim233/StickerDownloader/lib"
 	logger "github.com/swim233/StickerDownloader/logger"
+	"github.com/swim233/StickerDownloader/runtimeguard"
 	utils "github.com/swim233/StickerDownloader/utils"
 )
 
@@ -37,7 +38,7 @@ func InitDownloaderPool() {
 	}
 }
 
-func (p *BlockingPool) Get() *StickerDownloader { return <-p.pool }
+func (p *BlockingPool) Get() *StickerDownloader  { return <-p.pool }
 func (p *BlockingPool) Put(d *StickerDownloader) { p.pool <- d }
 
 // tr is a helper to get translated text for a user.
@@ -67,18 +68,7 @@ func (m MessageSender) ThisSender(format lib.TaskFileFormat, u tgbotapi.Update) 
 	chatID := u.CallbackQuery.Message.Chat.ID
 	userID := u.CallbackQuery.From.ID
 
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				logger.Error("panic 恢复: %v", r)
-				update, err := json.MarshalIndent(u, "", "  ")
-				if err == nil {
-					logger.Error("update: %s", string(update))
-				}
-				utils.RuntimeStatus.Errors.Add(1)
-			}
-		}()
-
+	runtimeguard.Go("single-sticker-download", runtimeguard.Task, func() {
 		if userID != 0 {
 			u.CallbackQuery.Answer(false, tr(userID).DownloadingSingleSticker)
 		}
@@ -133,7 +123,7 @@ func (m MessageSender) ThisSender(format lib.TaskFileFormat, u tgbotapi.Update) 
 			core.Bot.Send(msg)
 		}
 		u.CallbackQuery.Delete()
-	}()
+	})
 	return nil
 }
 
@@ -258,14 +248,7 @@ func (m MessageSender) ZipSender(format lib.TaskFileFormat, u tgbotapi.Update) e
 	replyMsg := callbackMsg.ReplyToMessage
 	replyMsgID := replyMsg.MessageID
 
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				logger.Error("下载贴纸包 panic 恢复: %v", r)
-				utils.RuntimeStatus.Errors.Add(1)
-			}
-		}()
-
+	runtimeguard.Go("sticker-pack-download", runtimeguard.Task, func() {
 		callback.Answer(false, tr(userID).DownloadingStickerSet)
 
 		stickerSetName := GetStickerSetName(u)
@@ -351,7 +334,7 @@ func (m MessageSender) ZipSender(format lib.TaskFileFormat, u tgbotapi.Update) e
 		}
 
 		u.CallbackQuery.Delete()
-	}()
+	})
 	return nil
 }
 

--- a/src/handler/message_send_handler.go
+++ b/src/handler/message_send_handler.go
@@ -75,6 +75,17 @@ func answerExpiredCallback(callback *tgbotapi.CallbackQuery) {
 	}
 }
 
+// recordBotDownload adds a WebUI history record for a bot-triggered download.
+func recordBotDownload(callback *tgbotapi.CallbackQuery, record lib.DownloadRecord) {
+	record.Source = lib.DownloadSourceBot
+	if callback != nil && callback.From != nil {
+		record.UserID = callback.From.ID
+		record.UserName = callback.From.UserName
+		record.DisplayName = strings.TrimSpace(callback.From.FirstName + " " + callback.From.LastName)
+	}
+	utils.DownloadHistory.Add(record)
+}
+
 // ThisSender downloads a single sticker in the requested format.
 func (m MessageSender) ThisSender(format lib.TaskFileFormat, u tgbotapi.Update) error {
 	callback := u.CallbackQuery
@@ -101,10 +112,23 @@ func (m MessageSender) ThisSender(format lib.TaskFileFormat, u tgbotapi.Update) 
 	replyMsgID := replyMsg.MessageID
 	fileID := sticker.FileID
 	fileSize := sticker.FileSize
-	stickerName := sticker.SetName
+	setName := sticker.SetName
+	stickerEmoji := sticker.Emoji
 	isVideo := sticker.IsVideo
+	stickerName := setName
 	if stickerName == "" {
 		stickerName = "sticker"
+	}
+	recordSingle := func(size int64, format lib.TaskFileFormat) {
+		recordBotDownload(callback, lib.DownloadRecord{
+			Kind:          lib.DownloadKindSingle,
+			SetName:       setName,
+			StickerFileID: fileID,
+			StickerEmoji:  stickerEmoji,
+			Format:        format.String(),
+			FileCount:     1,
+			FileSize:      size,
+		})
 	}
 
 	runtimeguard.Go("single-sticker-download", runtimeguard.Task, func() {
@@ -118,6 +142,7 @@ func (m MessageSender) ThisSender(format lib.TaskFileFormat, u tgbotapi.Update) 
 			msg.ReplyToMessageID = replyMsgID
 			utils.RuntimeStatus.SingleDownload.Add(1)
 			db.RecordUserData(u, int64(fileSize), 1)
+			recordSingle(int64(fileSize), format)
 			core.Bot.Send(msg)
 			callback.Delete()
 			return
@@ -135,6 +160,7 @@ func (m MessageSender) ThisSender(format lib.TaskFileFormat, u tgbotapi.Update) 
 			})
 			msg.ReplyToMessageID = replyMsgID
 			utils.RuntimeStatus.SingleDownload.Add(1)
+			recordSingle(int64(len(data)), format)
 			core.Bot.Send(msg)
 		} else {
 			webp, err := dl.DownloadFile(fileID)
@@ -151,6 +177,7 @@ func (m MessageSender) ThisSender(format lib.TaskFileFormat, u tgbotapi.Update) 
 			})
 			msg.ReplyToMessageID = replyMsgID
 			utils.RuntimeStatus.SingleDownload.Add(1)
+			recordSingle(int64(len(data)), format)
 			core.Bot.Send(msg)
 		}
 		callback.Delete()
@@ -312,6 +339,7 @@ func (m MessageSender) ZipSender(format lib.TaskFileFormat, u tgbotapi.Update) e
 		var requestFile tgbotapi.RequestFileData
 		var fileSize int64
 		var stickerNum int
+		var cacheHit bool
 
 		// Check cache
 		fileID, cachedSize, cachedNum, err := cache.GetCacheFileID(stickerSet, format)
@@ -319,6 +347,7 @@ func (m MessageSender) ZipSender(format lib.TaskFileFormat, u tgbotapi.Update) e
 			requestFile = tgbotapi.FileID(fileID)
 			fileSize = cachedSize
 			stickerNum = cachedNum
+			cacheHit = true
 			utils.RuntimeStatus.CacheHits.Add(1)
 			logger.Info("缓存命中: %s", stickerSet.Name)
 		} else {
@@ -377,6 +406,15 @@ func (m MessageSender) ZipSender(format lib.TaskFileFormat, u tgbotapi.Update) e
 			// Record cache data
 			recordStickerCache(stickerSet, userID, format, message.Document.FileID, fileSize)
 		}
+		recordBotDownload(callback, lib.DownloadRecord{
+			Kind:      lib.DownloadKindPack,
+			SetName:   stickerSet.Name,
+			SetTitle:  stickerSet.Title,
+			Format:    format.String(),
+			FileCount: stickerNum,
+			FileSize:  fileSize,
+			CacheHit:  cacheHit,
+		})
 
 		u.CallbackQuery.Delete()
 	})

--- a/src/handler/message_send_handler.go
+++ b/src/handler/message_send_handler.go
@@ -63,40 +63,71 @@ func (m MessageSender) ButtonMessageSender(u tgbotapi.Update, sticker tgbotapi.S
 	return nil
 }
 
+const expiredCallbackText = "操作已失效，请重新发送贴纸或贴纸包链接。\nThis action has expired. Please send the sticker or sticker pack link again."
+
+func answerExpiredCallback(callback *tgbotapi.CallbackQuery) {
+	utils.RuntimeStatus.RecordError(lib.RuntimeErrorRequest)
+	if callback == nil {
+		return
+	}
+	if _, err := callback.Answer(true, expiredCallbackText); err != nil {
+		logger.Warn("响应失效回调出错: %s", err)
+	}
+}
+
 // ThisSender downloads a single sticker in the requested format.
 func (m MessageSender) ThisSender(format lib.TaskFileFormat, u tgbotapi.Update) error {
-	chatID := u.CallbackQuery.Message.Chat.ID
-	userID := u.CallbackQuery.From.ID
+	callback := u.CallbackQuery
+	if callback == nil || callback.Message == nil || callback.Message.Chat == nil {
+		logger.Warn("无法下载单个贴纸：回调消息上下文不完整")
+		answerExpiredCallback(callback)
+		return nil
+	}
+
+	callbackMsg := callback.Message
+	chatID := callbackMsg.Chat.ID
+	userID := chatID
+	if callback.From != nil {
+		userID = callback.From.ID
+	}
+	if callbackMsg.ReplyToMessage == nil || callbackMsg.ReplyToMessage.Sticker == nil || callbackMsg.ReplyToMessage.Sticker.FileID == "" {
+		logger.Warn("无法下载单个贴纸：原始贴纸消息上下文已失效 (chat_id=%d, message_id=%d, user_id=%d)", chatID, callbackMsg.MessageID, userID)
+		answerExpiredCallback(callback)
+		return nil
+	}
+
+	replyMsg := callbackMsg.ReplyToMessage
+	sticker := replyMsg.Sticker
+	replyMsgID := replyMsg.MessageID
+	fileID := sticker.FileID
+	fileSize := sticker.FileSize
+	stickerName := sticker.SetName
+	isVideo := sticker.IsVideo
+	if stickerName == "" {
+		stickerName = "sticker"
+	}
 
 	runtimeguard.Go("single-sticker-download", runtimeguard.Task, func() {
 		if userID != 0 {
-			u.CallbackQuery.Answer(false, tr(userID).DownloadingSingleSticker)
+			callback.Answer(false, tr(userID).DownloadingSingleSticker)
 		}
-
-		replyMsg := u.CallbackQuery.Message.ReplyToMessage
-		replyMsgID := replyMsg.MessageID
 
 		// Fast path: webp format, just forward the file
 		if format == lib.WebpFormat {
-			msg := tgbotapi.NewDocument(chatID, tgbotapi.FileID(replyMsg.Sticker.FileID))
+			msg := tgbotapi.NewDocument(chatID, tgbotapi.FileID(fileID))
 			msg.ReplyToMessageID = replyMsgID
 			utils.RuntimeStatus.SingleDownload.Add(1)
-			db.RecordUserData(u, int64(replyMsg.Sticker.FileSize), 1)
+			db.RecordUserData(u, int64(fileSize), 1)
 			core.Bot.Send(msg)
-			u.CallbackQuery.Delete()
+			callback.Delete()
 			return
 		}
 
 		dl := downloaderPool.Get()
 		defer downloaderPool.Put(dl)
 
-		stickerName := replyMsg.Sticker.SetName
-		if stickerName == "" {
-			stickerName = "sticker"
-		}
-
-		if replyMsg.Sticker.IsVideo {
-			data, _ := dl.DownloadFile(u)
+		if isVideo {
+			data, _ := dl.DownloadFile(fileID)
 			db.RecordUserData(u, int64(len(data)), 1)
 			msg := tgbotapi.NewDocument(chatID, tgbotapi.FileBytes{
 				Bytes: data,
@@ -106,7 +137,7 @@ func (m MessageSender) ThisSender(format lib.TaskFileFormat, u tgbotapi.Update) 
 			utils.RuntimeStatus.SingleDownload.Add(1)
 			core.Bot.Send(msg)
 		} else {
-			webp, err := dl.DownloadFile(u)
+			webp, err := dl.DownloadFile(fileID)
 			if err != nil {
 				logger.Error("下载文件出错: %s", err)
 				return
@@ -122,7 +153,7 @@ func (m MessageSender) ThisSender(format lib.TaskFileFormat, u tgbotapi.Update) 
 			utils.RuntimeStatus.SingleDownload.Add(1)
 			core.Bot.Send(msg)
 		}
-		u.CallbackQuery.Delete()
+		callback.Delete()
 	})
 	return nil
 }
@@ -152,9 +183,26 @@ func convertStickerData(webp []byte, format lib.TaskFileFormat) []byte {
 
 // formatChooser is the unified implementation for ThisFormatChose and ZipFormatChose (Phase 4.3).
 func (m MessageSender) formatChooser(u tgbotapi.Update, callbackPrefix string) error {
-	editMsgID := u.CallbackQuery.Message.MessageID
-	chatID := u.CallbackQuery.Message.Chat.ID
-	userID := u.CallbackQuery.Message.ReplyToMessage.From.ID
+	callback := u.CallbackQuery
+	if callback == nil || callback.Message == nil || callback.Message.Chat == nil {
+		logger.Warn("无法选择下载格式：回调消息上下文不完整")
+		answerExpiredCallback(callback)
+		return nil
+	}
+
+	callbackMsg := callback.Message
+	chatID := callbackMsg.Chat.ID
+	userID := chatID
+	if callback.From != nil {
+		userID = callback.From.ID
+	}
+	if callbackMsg.ReplyToMessage == nil || (callbackPrefix == "" && (callbackMsg.ReplyToMessage.Sticker == nil || callbackMsg.ReplyToMessage.Sticker.FileID == "")) {
+		logger.Warn("无法选择下载格式：原始消息上下文已失效 (chat_id=%d, message_id=%d, user_id=%d)", chatID, callbackMsg.MessageID, userID)
+		answerExpiredCallback(callback)
+		return nil
+	}
+
+	editMsgID := callbackMsg.MessageID
 	t := tr(userID)
 
 	prefix := ""
@@ -225,7 +273,7 @@ func (m MessageSender) ChangeUserLanguage(u tgbotapi.Update, lang string) error 
 func (m MessageSender) ZipSender(format lib.TaskFileFormat, u tgbotapi.Update) error {
 	if u.CallbackQuery == nil || u.CallbackQuery.Message == nil || u.CallbackQuery.Message.Chat == nil {
 		logger.Warn("无法下载贴纸包：回调消息上下文不完整")
-		utils.RuntimeStatus.Errors.Add(1)
+		utils.RuntimeStatus.RecordError(lib.RuntimeErrorRequest)
 		return nil
 	}
 
@@ -238,10 +286,7 @@ func (m MessageSender) ZipSender(format lib.TaskFileFormat, u tgbotapi.Update) e
 	}
 	if callbackMsg.ReplyToMessage == nil {
 		logger.Warn("无法下载贴纸包：原始消息上下文已失效 (chat_id=%d, message_id=%d, user_id=%d)", chatID, callbackMsg.MessageID, userID)
-		utils.RuntimeStatus.Errors.Add(1)
-		if _, err := callback.Answer(true, "操作已失效，请重新发送贴纸或贴纸包链接。\nThis action has expired. Please send the sticker or sticker pack link again."); err != nil {
-			logger.Warn("响应失效回调出错: %s", err)
-		}
+		answerExpiredCallback(callback)
 		return nil
 	}
 
@@ -254,7 +299,7 @@ func (m MessageSender) ZipSender(format lib.TaskFileFormat, u tgbotapi.Update) e
 		stickerSetName := GetStickerSetName(u)
 		if stickerSetName == "" {
 			logger.Warn("无法下载贴纸包：原始消息中没有贴纸包信息 (chat_id=%d, message_id=%d, user_id=%d)", chatID, callbackMsg.MessageID, userID)
-			utils.RuntimeStatus.Errors.Add(1)
+			utils.RuntimeStatus.RecordError(lib.RuntimeErrorRequest)
 			return
 		}
 

--- a/src/handler/message_send_handler_test.go
+++ b/src/handler/message_send_handler_test.go
@@ -1,0 +1,239 @@
+package handler
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	tgbotapi "github.com/ijnkawakaze/telegram-bot-api"
+	"github.com/swim233/StickerDownloader/core"
+	db "github.com/swim233/StickerDownloader/db"
+	"github.com/swim233/StickerDownloader/lib"
+	"github.com/swim233/StickerDownloader/logger"
+	"github.com/swim233/StickerDownloader/utils"
+	"gorm.io/gorm"
+)
+
+func TestThisSenderRejectsExpiredCallback(t *testing.T) {
+	logger.InitLogger()
+
+	var (
+		mu      sync.Mutex
+		methods []string
+		bodies  []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		methods = append(methods, method)
+		bodies = append(bodies, string(body))
+		mu.Unlock()
+
+		if method == "getMe" {
+			_, _ = w.Write([]byte(`{"ok":true,"result":{"id":1,"is_bot":true,"first_name":"test","username":"test_bot"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"result":{}}`))
+	}))
+	defer server.Close()
+
+	bot, err := tgbotapi.NewBotAPIWithAPIEndpoint("test-token", server.URL+"/bot%s/%s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldBot := core.Bot
+	core.Bot = bot
+	defer func() { core.Bot = oldBot }()
+
+	oldErrors := utils.RuntimeStatus.Errors.Load()
+	oldRequestErrors := utils.RuntimeStatus.RequestErrors.Load()
+	oldPanicErrors := utils.RuntimeStatus.PanicErrors.Load()
+	oldDownloadErrors := utils.RuntimeStatus.DownloadErrors.Load()
+	oldDownloads := utils.RuntimeStatus.SingleDownload.Load()
+	defer func() {
+		utils.RuntimeStatus.Errors.Store(oldErrors)
+		utils.RuntimeStatus.RequestErrors.Store(oldRequestErrors)
+		utils.RuntimeStatus.PanicErrors.Store(oldPanicErrors)
+		utils.RuntimeStatus.DownloadErrors.Store(oldDownloadErrors)
+		utils.RuntimeStatus.SingleDownload.Store(oldDownloads)
+	}()
+
+	baseUpdate := func() tgbotapi.Update {
+		return tgbotapi.Update{CallbackQuery: &tgbotapi.CallbackQuery{
+			ID:   "callback-id",
+			From: &tgbotapi.User{ID: 42},
+			Message: &tgbotapi.Message{
+				MessageID: 7,
+				Chat:      &tgbotapi.Chat{ID: 42},
+				ReplyToMessage: &tgbotapi.Message{
+					MessageID: 6,
+				},
+			},
+		}}
+	}
+
+	tests := []struct {
+		name   string
+		update func() tgbotapi.Update
+		alert  bool
+	}{
+		{name: "callback missing", update: func() tgbotapi.Update { return tgbotapi.Update{} }},
+		{name: "message missing", update: func() tgbotapi.Update {
+			return tgbotapi.Update{CallbackQuery: &tgbotapi.CallbackQuery{ID: "callback-id"}}
+		}, alert: true},
+		{name: "chat missing", update: func() tgbotapi.Update {
+			u := baseUpdate()
+			u.CallbackQuery.Message.Chat = nil
+			return u
+		}, alert: true},
+		{name: "reply missing", update: func() tgbotapi.Update {
+			u := baseUpdate()
+			u.CallbackQuery.Message.ReplyToMessage = nil
+			return u
+		}, alert: true},
+		{name: "sticker missing", update: baseUpdate, alert: true},
+		{name: "file id missing", update: func() tgbotapi.Update {
+			u := baseUpdate()
+			u.CallbackQuery.Message.ReplyToMessage.Sticker = &tgbotapi.Sticker{}
+			return u
+		}, alert: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			beforeErrors := utils.RuntimeStatus.Errors.Load()
+			beforeRequestErrors := utils.RuntimeStatus.RequestErrors.Load()
+			beforePanicErrors := utils.RuntimeStatus.PanicErrors.Load()
+			beforeDownloadErrors := utils.RuntimeStatus.DownloadErrors.Load()
+			beforeDownloads := utils.RuntimeStatus.SingleDownload.Load()
+			mu.Lock()
+			beforeCalls := len(methods)
+			mu.Unlock()
+
+			if err := (MessageSender{}).ThisSender(lib.PngFormat, tt.update()); err != nil {
+				t.Fatal(err)
+			}
+			if got := utils.RuntimeStatus.Errors.Load(); got != beforeErrors+1 {
+				t.Fatalf("Errors = %d, want %d", got, beforeErrors+1)
+			}
+			if got := utils.RuntimeStatus.RequestErrors.Load(); got != beforeRequestErrors+1 {
+				t.Fatalf("RequestErrors = %d, want %d", got, beforeRequestErrors+1)
+			}
+			if got := utils.RuntimeStatus.PanicErrors.Load(); got != beforePanicErrors {
+				t.Fatalf("PanicErrors changed: %d -> %d", beforePanicErrors, got)
+			}
+			if got := utils.RuntimeStatus.DownloadErrors.Load(); got != beforeDownloadErrors {
+				t.Fatalf("DownloadErrors changed: %d -> %d", beforeDownloadErrors, got)
+			}
+			if got := utils.RuntimeStatus.SingleDownload.Load(); got != beforeDownloads {
+				t.Fatalf("SingleDownload changed: %d -> %d", beforeDownloads, got)
+			}
+
+			mu.Lock()
+			newMethods := append([]string(nil), methods[beforeCalls:]...)
+			newBodies := append([]string(nil), bodies[beforeCalls:]...)
+			mu.Unlock()
+			if !tt.alert {
+				if len(newMethods) != 0 {
+					t.Fatalf("unexpected API calls: %v", newMethods)
+				}
+				return
+			}
+			if len(newMethods) != 1 || newMethods[0] != "answerCallbackQuery" {
+				t.Fatalf("API calls = %v, want one answerCallbackQuery", newMethods)
+			}
+			if !strings.Contains(newBodies[0], "show_alert=true") || !strings.Contains(newBodies[0], "This+action+has+expired") {
+				t.Fatalf("unexpected callback answer: %s", newBodies[0])
+			}
+		})
+	}
+}
+
+func TestFormatChooserHandlesExpiredSingleAndZipTextReply(t *testing.T) {
+	logger.InitLogger()
+
+	var (
+		mu      sync.Mutex
+		methods []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+		mu.Lock()
+		methods = append(methods, method)
+		mu.Unlock()
+		if method == "getMe" {
+			_, _ = w.Write([]byte(`{"ok":true,"result":{"id":1,"is_bot":true,"first_name":"test","username":"test_bot"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"result":{}}`))
+	}))
+	defer server.Close()
+
+	bot, err := tgbotapi.NewBotAPIWithAPIEndpoint("test-token", server.URL+"/bot%s/%s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldBot := core.Bot
+	core.Bot = bot
+	defer func() { core.Bot = oldBot }()
+
+	oldDB := db.DB
+	db.DB, err = gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.DB.AutoMigrate(&db.UserData{}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { db.DB = oldDB }()
+
+	oldTranslations := lib.TranslationsMap
+	lib.TranslationsMap = map[string]lib.Translations{
+		"zh": {PickDownloadFormat: "选择格式", Cancel: "取消"},
+	}
+	defer func() { lib.TranslationsMap = oldTranslations }()
+
+	oldErrors := utils.RuntimeStatus.Errors.Load()
+	oldRequestErrors := utils.RuntimeStatus.RequestErrors.Load()
+	defer func() {
+		utils.RuntimeStatus.Errors.Store(oldErrors)
+		utils.RuntimeStatus.RequestErrors.Store(oldRequestErrors)
+	}()
+
+	update := tgbotapi.Update{CallbackQuery: &tgbotapi.CallbackQuery{
+		ID: "callback-id",
+		Message: &tgbotapi.Message{
+			MessageID: 7,
+			Chat:      &tgbotapi.Chat{ID: 42},
+			ReplyToMessage: &tgbotapi.Message{
+				MessageID: 6,
+				Text:      "https://t.me/addstickers/example",
+			},
+		},
+	}}
+
+	if err := (MessageSender{}).ThisFormatChose(update); err != nil {
+		t.Fatal(err)
+	}
+	if got := utils.RuntimeStatus.Errors.Load(); got != oldErrors+1 {
+		t.Fatalf("Errors = %d, want %d", got, oldErrors+1)
+	}
+	if got := utils.RuntimeStatus.RequestErrors.Load(); got != oldRequestErrors+1 {
+		t.Fatalf("RequestErrors = %d, want %d", got, oldRequestErrors+1)
+	}
+	if err := (MessageSender{}).ZipFormatChose(update); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	gotMethods := append([]string(nil), methods...)
+	mu.Unlock()
+	if len(gotMethods) != 3 || gotMethods[0] != "getMe" || gotMethods[1] != "answerCallbackQuery" || gotMethods[2] != "editMessageText" {
+		t.Fatalf("API calls = %v", gotMethods)
+	}
+}

--- a/src/handler/sticker_downloader_handler.go
+++ b/src/handler/sticker_downloader_handler.go
@@ -21,12 +21,26 @@ import (
 	"github.com/swim233/StickerDownloader/core"
 	"github.com/swim233/StickerDownloader/lib"
 	"github.com/swim233/StickerDownloader/logger"
+	"github.com/swim233/StickerDownloader/runtimeguard"
 	"github.com/swim233/StickerDownloader/utils"
 )
 
 // StickerDownloader handles downloading sticker files from Telegram.
 type StickerDownloader struct {
 	ID int
+}
+
+var (
+	fileDownloadSlots     chan struct{}
+	fileDownloadSlotsOnce sync.Once
+)
+
+func acquireFileDownloadSlot() func() {
+	fileDownloadSlotsOnce.Do(func() {
+		fileDownloadSlots = make(chan struct{}, config.MaxConcurrency)
+	})
+	fileDownloadSlots <- struct{}{}
+	return func() { <-fileDownloadSlots }
 }
 
 // DownloadFile downloads a single sticker file from a callback update.
@@ -42,6 +56,9 @@ func (s StickerDownloader) DownloadSetFile(sticker tgbotapi.Sticker) ([]byte, er
 
 // downloadByFileID is the shared implementation for downloading a file by its ID.
 func downloadByFileID(fileID string) ([]byte, error) {
+	releaseSlot := acquireFileDownloadSlot()
+	defer releaseSlot()
+
 	var lastErr error
 	for i := 0; i < config.MaxRetry; i++ {
 		file, err := core.Bot.GetFile(tgbotapi.FileConfig{FileID: fileID})
@@ -51,6 +68,7 @@ func downloadByFileID(fileID string) ([]byte, error) {
 			continue
 		}
 		fileURL := fmt.Sprintf("https://api.telegram.org/file/bot%s/%s", core.Bot.Token, file.FilePath)
+		logger.Debug("开始下载 Telegram 文件: %s", filepath.Base(file.FilePath))
 
 		resp, err := http.Get(fileURL)
 		if err != nil {
@@ -58,18 +76,23 @@ func downloadByFileID(fileID string) ([]byte, error) {
 			logger.Warn("下载文件失败 (重试 %d/%d): %s", i+1, config.MaxRetry, err)
 			continue
 		}
-		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+			_ = resp.Body.Close()
 			lastErr = fmt.Errorf("下载文件返回非 200 状态码: %d", resp.StatusCode)
 			logger.Warn("下载返回状态码 %d (重试 %d/%d)", resp.StatusCode, i+1, config.MaxRetry)
 			continue
 		}
 
-		data, err := io.ReadAll(resp.Body)
-		if err != nil {
-			lastErr = fmt.Errorf("读取响应失败: %w", err)
+		data, readErr := io.ReadAll(resp.Body)
+		closeErr := resp.Body.Close()
+		if readErr != nil {
+			lastErr = fmt.Errorf("读取响应失败: %w", readErr)
 			continue
+		}
+		if closeErr != nil {
+			logger.Debug("关闭下载响应失败: %s", closeErr)
 		}
 		return data, nil
 	}
@@ -99,7 +122,7 @@ func downloadAndPackStickers(format string, stickerSet tgbotapi.StickerSet, onPr
 	var tickerDone chan struct{}
 	if onProgress != nil {
 		tickerDone = make(chan struct{})
-		go func() {
+		runtimeguard.Go("sticker-progress", runtimeguard.Task, func() {
 			ticker := time.NewTicker(3 * time.Second)
 			defer ticker.Stop()
 			for {
@@ -110,13 +133,13 @@ func downloadAndPackStickers(format string, stickerSet tgbotapi.StickerSet, onPr
 					return
 				}
 			}
-		}()
+		})
 	}
 
 	dl := StickerDownloader{}
 	wg.Add(stickerNum)
 	for index, sticker := range stickerSet.Stickers {
-		go func(index int, sticker tgbotapi.Sticker) {
+		runtimeguard.Go("sticker-file-download", runtimeguard.Task, func() {
 			defer wg.Done()
 
 			data, err := dl.DownloadSetFile(sticker)
@@ -143,7 +166,7 @@ func downloadAndPackStickers(format string, stickerSet tgbotapi.StickerSet, onPr
 				mu.Unlock()
 			}
 			completed.Add(1)
-		}(index, sticker)
+		})
 	}
 	wg.Wait()
 
@@ -225,10 +248,10 @@ func (s StickerDownloader) HTTPDownloadStickerSet(format string, setName string)
 	return zipData, nil
 }
 
+var stickerLinkRegex = regexp.MustCompile(`https?://t\.me/addstickers/([a-zA-Z0-9_]+)`)
+
 // GetStickerSetName extracts the sticker set name from an update (callback query).
 func GetStickerSetName(u tgbotapi.Update) string {
-	var stickerLinkRegex = regexp.MustCompile(`https://t.me/addstickers/([a-zA-Z0-9_]+)`)
-
 	if u.CallbackQuery == nil || u.CallbackQuery.Message == nil || u.CallbackQuery.Message.ReplyToMessage == nil {
 		return ""
 	}

--- a/src/handler/sticker_downloader_handler.go
+++ b/src/handler/sticker_downloader_handler.go
@@ -43,9 +43,8 @@ func acquireFileDownloadSlot() func() {
 	return func() { <-fileDownloadSlots }
 }
 
-// DownloadFile downloads a single sticker file from a callback update.
-func (s StickerDownloader) DownloadFile(u tgbotapi.Update) ([]byte, error) {
-	fileID := u.CallbackQuery.Message.ReplyToMessage.Sticker.FileID
+// DownloadFile downloads a single sticker file by its Telegram file ID.
+func (s StickerDownloader) DownloadFile(fileID string) ([]byte, error) {
 	return downloadByFileID(fileID)
 }
 
@@ -96,7 +95,7 @@ func downloadByFileID(fileID string) ([]byte, error) {
 		}
 		return data, nil
 	}
-	utils.RuntimeStatus.Errors.Add(1)
+	utils.RuntimeStatus.RecordError(lib.RuntimeErrorDownload)
 	return nil, lastErr
 }
 
@@ -229,7 +228,7 @@ func (s StickerDownloader) DownloadStickerSet(format lib.TaskFileFormat, sticker
 // HTTPDownloadStickerSet downloads and zips a sticker set via HTTP API.
 func (s StickerDownloader) HTTPDownloadStickerSet(format string, setName string) ([]byte, error) {
 	if format != "webp" && format != "png" && format != "jpeg" {
-		utils.RuntimeStatus.Errors.Add(1)
+		utils.RuntimeStatus.RecordError(lib.RuntimeErrorRequest)
 		return nil, errors.New("invalid format: must be webp, png, or jpeg")
 	}
 
@@ -240,7 +239,7 @@ func (s StickerDownloader) HTTPDownloadStickerSet(format string, setName string)
 
 	zipData, _, err := downloadAndPackStickers(format, stickerSet, nil)
 	if err != nil {
-		utils.RuntimeStatus.Errors.Add(1)
+		utils.RuntimeStatus.RecordError(lib.RuntimeErrorDownload)
 		return nil, err
 	}
 

--- a/src/handler/sticker_downloader_handler.go
+++ b/src/handler/sticker_downloader_handler.go
@@ -237,13 +237,23 @@ func (s StickerDownloader) HTTPDownloadStickerSet(format string, setName string)
 		return nil, err
 	}
 
-	zipData, _, err := downloadAndPackStickers(format, stickerSet, nil)
+	zipData, stickerNum, err := downloadAndPackStickers(format, stickerSet, nil)
 	if err != nil {
 		utils.RuntimeStatus.RecordError(lib.RuntimeErrorDownload)
 		return nil, err
 	}
 
 	utils.RuntimeStatus.HTTPPackDownload.Add(1)
+	utils.DownloadHistory.Add(lib.DownloadRecord{
+		Source:      lib.DownloadSourceHTTP,
+		Kind:        lib.DownloadKindPack,
+		DisplayName: "HTTP API",
+		SetName:     stickerSet.Name,
+		SetTitle:    stickerSet.Title,
+		Format:      format,
+		FileCount:   stickerNum,
+		FileSize:    int64(len(zipData)),
+	})
 	return zipData, nil
 }
 

--- a/src/lib/download_history.go
+++ b/src/lib/download_history.go
@@ -1,0 +1,115 @@
+package lib
+
+import (
+	"sync"
+	"time"
+)
+
+// DefaultDownloadHistorySize is used when no valid capacity is configured.
+const DefaultDownloadHistorySize = 10
+
+const (
+	DownloadSourceBot  = "bot"
+	DownloadSourceHTTP = "http"
+
+	DownloadKindSingle = "single"
+	DownloadKindPack   = "pack"
+)
+
+// DownloadRecord describes one completed download for the WebUI history view.
+type DownloadRecord struct {
+	Time          time.Time `json:"time"`
+	Source        string    `json:"source"`
+	Kind          string    `json:"kind"`
+	UserID        int64     `json:"user_id,omitempty"`
+	UserName      string    `json:"user_name,omitempty"`
+	DisplayName   string    `json:"display_name,omitempty"`
+	SetName       string    `json:"set_name,omitempty"`
+	SetTitle      string    `json:"set_title,omitempty"`
+	StickerFileID string    `json:"sticker_file_id,omitempty"`
+	StickerEmoji  string    `json:"sticker_emoji,omitempty"`
+	Format        string    `json:"format"`
+	FileCount     int       `json:"file_count"`
+	FileSize      int64     `json:"file_size"`
+	CacheHit      bool      `json:"cache_hit,omitempty"`
+}
+
+// DownloadHistory keeps the most recent download records in memory.
+type DownloadHistory struct {
+	mu       sync.Mutex
+	capacity int
+	records  []DownloadRecord
+	persist  func(DownloadRecord)
+}
+
+func NewDownloadHistory(capacity int) *DownloadHistory {
+	if capacity <= 0 {
+		capacity = DefaultDownloadHistorySize
+	}
+	return &DownloadHistory{capacity: capacity}
+}
+
+// SetCapacity resizes the history, dropping the oldest records if needed.
+func (h *DownloadHistory) SetCapacity(capacity int) {
+	if capacity <= 0 {
+		capacity = DefaultDownloadHistorySize
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.capacity = capacity
+	if len(h.records) > capacity {
+		h.records = append([]DownloadRecord(nil), h.records[len(h.records)-capacity:]...)
+	}
+}
+
+func (h *DownloadHistory) Capacity() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.capacity
+}
+
+// SetPersist installs a hook called with every record passed to Add.
+func (h *DownloadHistory) SetPersist(persist func(DownloadRecord)) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.persist = persist
+}
+
+// Seed replaces the in-memory records with previously persisted ones
+// (oldest first) without invoking the persist hook.
+func (h *DownloadHistory) Seed(records []DownloadRecord) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(records) > h.capacity {
+		records = records[len(records)-h.capacity:]
+	}
+	h.records = append([]DownloadRecord(nil), records...)
+}
+
+// Add appends a record, evicting the oldest once the capacity is reached.
+func (h *DownloadHistory) Add(record DownloadRecord) {
+	if record.Time.IsZero() {
+		record.Time = time.Now()
+	}
+	h.mu.Lock()
+	h.records = append(h.records, record)
+	if len(h.records) > h.capacity {
+		h.records = h.records[len(h.records)-h.capacity:]
+	}
+	persist := h.persist
+	h.mu.Unlock()
+	if persist != nil {
+		persist(record)
+	}
+}
+
+// Recent returns a copy of the stored records, newest first.
+func (h *DownloadHistory) Recent() []DownloadRecord {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	recent := make([]DownloadRecord, len(h.records))
+	for i, record := range h.records {
+		recent[len(h.records)-1-i] = record
+	}
+	return recent
+}

--- a/src/lib/download_history_test.go
+++ b/src/lib/download_history_test.go
@@ -1,0 +1,77 @@
+package lib
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDownloadHistoryEvictsOldest(t *testing.T) {
+	h := NewDownloadHistory(3)
+	for i := range 5 {
+		h.Add(DownloadRecord{SetName: string(rune('a' + i)), Time: time.Unix(int64(i), 0)})
+	}
+	recent := h.Recent()
+	if len(recent) != 3 {
+		t.Fatalf("len = %d, want 3", len(recent))
+	}
+	if recent[0].SetName != "e" || recent[2].SetName != "c" {
+		t.Fatalf("recent = %v, want newest first e..c", recent)
+	}
+}
+
+func TestDownloadHistoryDefaultCapacity(t *testing.T) {
+	h := NewDownloadHistory(0)
+	if got := h.Capacity(); got != DefaultDownloadHistorySize {
+		t.Fatalf("Capacity = %d, want %d", got, DefaultDownloadHistorySize)
+	}
+}
+
+func TestDownloadHistorySetCapacityDropsOldest(t *testing.T) {
+	h := NewDownloadHistory(5)
+	for i := range 5 {
+		h.Add(DownloadRecord{SetName: string(rune('a' + i)), Time: time.Unix(int64(i), 0)})
+	}
+	h.SetCapacity(2)
+	recent := h.Recent()
+	if len(recent) != 2 {
+		t.Fatalf("len = %d, want 2", len(recent))
+	}
+	if recent[0].SetName != "e" || recent[1].SetName != "d" {
+		t.Fatalf("recent = %v, want e,d", recent)
+	}
+}
+
+func TestDownloadHistorySeedSkipsPersistAndTrims(t *testing.T) {
+	h := NewDownloadHistory(2)
+	persisted := 0
+	h.SetPersist(func(DownloadRecord) { persisted++ })
+
+	h.Seed([]DownloadRecord{
+		{SetName: "a", Time: time.Unix(0, 0)},
+		{SetName: "b", Time: time.Unix(1, 0)},
+		{SetName: "c", Time: time.Unix(2, 0)},
+	})
+	if persisted != 0 {
+		t.Fatalf("persisted = %d, want 0 after Seed", persisted)
+	}
+	recent := h.Recent()
+	if len(recent) != 2 || recent[0].SetName != "c" || recent[1].SetName != "b" {
+		t.Fatalf("recent = %v, want c,b", recent)
+	}
+
+	h.Add(DownloadRecord{SetName: "d"})
+	if persisted != 1 {
+		t.Fatalf("persisted = %d, want 1 after Add", persisted)
+	}
+	if got := h.Recent()[0].SetName; got != "d" {
+		t.Fatalf("newest = %s, want d", got)
+	}
+}
+
+func TestDownloadHistoryAddStampsTime(t *testing.T) {
+	h := NewDownloadHistory(1)
+	h.Add(DownloadRecord{SetName: "a"})
+	if h.Recent()[0].Time.IsZero() {
+		t.Fatal("expected Add to stamp a zero Time")
+	}
+}

--- a/src/lib/runtime_status_types.go
+++ b/src/lib/runtime_status_types.go
@@ -5,6 +5,15 @@ import (
 	"time"
 )
 
+type RuntimeErrorCategory int
+
+const (
+	RuntimeErrorPanic RuntimeErrorCategory = iota
+	RuntimeErrorRequest
+	RuntimeErrorDownload
+	RuntimeErrorNotification
+)
+
 type RuntimeStatus struct {
 	StartTime          time.Time
 	SingleDownload     atomic.Int64
@@ -12,5 +21,25 @@ type RuntimeStatus struct {
 	HTTPSingleDownload atomic.Int64
 	HTTPPackDownload   atomic.Int64
 	Errors             atomic.Int64
+	PanicErrors        atomic.Int64
+	RequestErrors      atomic.Int64
+	DownloadErrors     atomic.Int64
+	NotificationErrors atomic.Int64
 	CacheHits          atomic.Int64
+}
+
+func (s *RuntimeStatus) RecordError(category RuntimeErrorCategory) {
+	switch category {
+	case RuntimeErrorPanic:
+		s.PanicErrors.Add(1)
+	case RuntimeErrorRequest:
+		s.RequestErrors.Add(1)
+	case RuntimeErrorDownload:
+		s.DownloadErrors.Add(1)
+	case RuntimeErrorNotification:
+		s.NotificationErrors.Add(1)
+	default:
+		return
+	}
+	s.Errors.Add(1)
 }

--- a/src/lib/runtime_status_types_test.go
+++ b/src/lib/runtime_status_types_test.go
@@ -1,0 +1,41 @@
+package lib
+
+import "testing"
+
+func TestRuntimeStatusRecordError(t *testing.T) {
+	var status RuntimeStatus
+	status.RecordError(RuntimeErrorPanic)
+	status.RecordError(RuntimeErrorRequest)
+	status.RecordError(RuntimeErrorRequest)
+	status.RecordError(RuntimeErrorDownload)
+	status.RecordError(RuntimeErrorNotification)
+
+	if got := status.Errors.Load(); got != 5 {
+		t.Fatalf("Errors = %d, want 5", got)
+	}
+	if got := status.PanicErrors.Load(); got != 1 {
+		t.Fatalf("PanicErrors = %d, want 1", got)
+	}
+	if got := status.RequestErrors.Load(); got != 2 {
+		t.Fatalf("RequestErrors = %d, want 2", got)
+	}
+	if got := status.DownloadErrors.Load(); got != 1 {
+		t.Fatalf("DownloadErrors = %d, want 1", got)
+	}
+	if got := status.NotificationErrors.Load(); got != 1 {
+		t.Fatalf("NotificationErrors = %d, want 1", got)
+	}
+
+	sum := status.PanicErrors.Load() + status.RequestErrors.Load() + status.DownloadErrors.Load() + status.NotificationErrors.Load()
+	if status.Errors.Load() != sum {
+		t.Fatalf("Errors = %d, category sum = %d", status.Errors.Load(), sum)
+	}
+}
+
+func TestRuntimeStatusIgnoresUnknownErrorCategory(t *testing.T) {
+	var status RuntimeStatus
+	status.RecordError(RuntimeErrorCategory(99))
+	if got := status.Errors.Load(); got != 0 {
+		t.Fatalf("Errors = %d, want 0", got)
+	}
+}

--- a/src/logger/logger.go
+++ b/src/logger/logger.go
@@ -60,7 +60,7 @@ func InitLogger() {
 		level,
 	)
 
-	logger = zap.New(core, zap.AddCaller())
+	logger = zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1))
 	sugar = logger.Sugar()
 }
 

--- a/src/main.go
+++ b/src/main.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
+	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	tgbotapi "github.com/ijnkawakaze/telegram-bot-api"
@@ -15,6 +21,9 @@ import (
 	"github.com/swim233/StickerDownloader/lib"
 	"github.com/swim233/StickerDownloader/logger"
 	"github.com/swim233/StickerDownloader/message"
+	"github.com/swim233/StickerDownloader/notify"
+	"github.com/swim233/StickerDownloader/runtimeguard"
+	"github.com/swim233/StickerDownloader/supervisor"
 	"github.com/swim233/StickerDownloader/task"
 	"github.com/swim233/StickerDownloader/utils"
 )
@@ -25,49 +34,126 @@ var (
 	buildTime  string
 )
 
+var stickerPackLinkRegex = regexp.MustCompile(`https?://t\.me/addstickers/[a-zA-Z0-9_]+`)
+
 func main() {
-	// 1. Initialize logger
-	logger.InitLogger()
-	logBuildInfo()
+	os.Exit(run(os.Args[1:]))
+}
 
-	// 2. Load configuration
-	config.InitConfig()
-	logger.SetLogLevel(config.LogLevel)
-
-	// 3. Initialize database
-	db.InitDB()
-
-	// 4. Initialize bot
-	core.InitBot()
-	b := core.Bot.AddHandle()
-
-	// 5. Initialize downloader pool
-	handler.InitDownloaderPool()
-
-	// 6. Start HTTP server
-	go api.StartHTTPServer()
-
-	// 7. Load translations
-	if err := handler.LoadTranslations(); err != nil {
-		logger.Error("加载 i18n 文件出错: %s", err)
-		os.Exit(1)
+func run(args []string) int {
+	flags := flag.NewFlagSet("stickerDownloader", flag.ContinueOnError)
+	worker := flags.Bool("worker", false, "internal worker mode")
+	configPath := flags.String("config", "", "配置文件路径")
+	if err := flags.Parse(args); err != nil {
+		return supervisor.ExitUsage
 	}
 
-	// 8. Start task manager
-	go task.TaskManager()
-	logger.Info("任务管理器启动成功")
+	settings, usedPath, err := config.Load(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "配置错误: %v\n", err)
+		return supervisor.ExitConfig
+	}
+	if settings.OwnerChatID == 0 {
+		fmt.Fprintln(os.Stderr, "警告: telegram.owner_chat_id 为 0，运维通知已禁用")
+	}
 
-	// 9. Register handlers
-	ms := handler.MessageSender{}
-	registerHandlers(b, ms)
+	notifier := notify.New(notify.Config{
+		Token:       settings.BotToken,
+		OwnerChatID: settings.OwnerChatID,
+		APIEndpoint: settings.TelegramAPIEndpoint,
+		Timeout:     settings.Notification.RequestTimeout,
+		DedupWindow: settings.Notification.PanicDedup,
+		MaxStack:    settings.Notification.MaxStackBytes,
+	})
+	if *worker {
+		return runWorker(settings, notifier)
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "无法确定当前二进制路径: %v\n", err)
+		return supervisor.ExitUsage
+	}
+	return supervisor.New(executable, usedPath, settings, notifier).Run(context.Background())
+}
 
-	// 10. Start bot
-	utils.RuntimeStatus.StartTime = time.Now()
-	b.Run()
+func runWorker(settings config.Settings, notifier *notify.Telegram) (exitCode int) {
+	config.Apply(settings)
+	logger.InitLogger()
+	logger.SetLogLevel(config.LogLevel)
+	logBuildInfo()
+
+	runID := os.Getenv("STICKERDOWNLOADER_RUN_ID")
+	generation := os.Getenv("STICKERDOWNLOADER_GENERATION")
+	startedAt := time.Now()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			logger.Error("worker 主流程 panic: %v", recovered)
+			ctx, cancel := context.WithTimeout(context.Background(), settings.Notification.RequestTimeout)
+			_ = notifier.SendPanic(ctx, "worker-main", recovered, nil, "Run: "+runID+"\nGeneration: "+generation)
+			cancel()
+			exitCode = supervisor.ExitCrash
+		}
+	}()
+
+	if err := db.InitDB(); err != nil {
+		logger.Error("数据库初始化失败: %s", err)
+		return supervisor.ExitTemporary
+	}
+	if err := core.InitBot(); err != nil {
+		logger.Error("Bot 初始化失败: %s", err)
+		return supervisor.ExitTemporary
+	}
+	if err := handler.LoadTranslations(); err != nil {
+		return supervisor.ExitConfig
+	}
+	handler.InitDownloaderPool()
+	b := core.Bot.AddHandle()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	fatal := make(chan error, 4)
+	guard := &runtimeguard.Guard{
+		Notifier:      notifier,
+		Fatal:         fatal,
+		RunID:         runID,
+		Generation:    generation,
+		StartTime:     startedAt,
+		NotifyTimeout: settings.Notification.RequestTimeout,
+	}
+	runtimeguard.SetDefault(guard)
+	defer runtimeguard.SetDefault(nil)
+
+	registerHandlers(b, handler.MessageSender{}, guard)
+	guard.Go("http-server", runtimeguard.Critical, func() {
+		if err := api.RunHTTPServer(ctx); err != nil {
+			panic(err)
+		}
+	})
+	guard.Go("task-manager", runtimeguard.Critical, func() { task.TaskManager() })
+	guard.Go("telegram-polling", runtimeguard.Critical, func() { b.Run() })
+
+	utils.RuntimeStatus.StartTime = startedAt
+	workerPID := os.Getpid()
+	readyText := fmt.Sprintf("✅ StickerDownloader 已启动\nRun: %s\nGeneration: %s\nPID: %d\nVersion: %s\nCommit: %s", runID, generation, workerPID, version, commitHash)
+	notifyCtx, cancelNotify := context.WithTimeout(context.Background(), settings.Notification.RequestTimeout)
+	if err := notifier.SendEvent(notifyCtx, runID+":"+generation+":started", readyText); err != nil {
+		logger.Warn("发送启动通知失败: %s", err)
+	}
+	cancelNotify()
+	logger.Info("服务启动成功")
+
+	select {
+	case <-ctx.Done():
+		logger.Info("收到停止信号")
+		core.Bot.StopReceivingUpdates()
+		return supervisor.ExitOK
+	case err := <-fatal:
+		logger.Error("关键组件退出: %s", err)
+		return supervisor.ExitCrash
+	}
 }
 
 func logBuildInfo() {
-	// Fallback: read from git if ldflags were not set
 	if version == "" {
 		version = gitOutput("describe", "--tags", "--abbrev=0", "--always")
 	}
@@ -95,53 +181,47 @@ func gitOutput(args ...string) string {
 	return strings.TrimSpace(string(out))
 }
 
-func registerHandlers(b *tgbotapi.Bot, ms handler.MessageSender) {
-	// Message processor: generate task message for incoming stickers
+func registerHandlers(b *tgbotapi.Bot, ms handler.MessageSender, guard *runtimeguard.Guard) {
+	wrap := func(name string, fn func(tgbotapi.Update) error) func(tgbotapi.Update) error {
+		return func(u tgbotapi.Update) error {
+			return guard.Wrap(name, func() error { return fn(u) })()
+		}
+	}
+
 	b.NewProcessor(func(u tgbotapi.Update) bool {
-		if u.Message == nil || u.Message.From == nil {
+		if !isDownloadableStickerMessage(u.Message) {
 			return false
 		}
 		message.GenerateNewTaskMessage(u.Message.From.ID, u.Message.Chat.ID, u.Message.MessageID)
 		return false
 	}, nil)
 
-	// Private commands
-	b.NewPrivateCommandProcessor("count", utils.SendRuntimeStatusInfo)
-	b.NewPrivateCommandProcessor("help", ms.HelpMessage)
-	b.NewPrivateCommandProcessor("start", ms.StartMessage)
-	b.NewPrivateCommandProcessor("lang", ms.LanguageChose)
+	b.NewPrivateCommandProcessor("count", wrap("command-count", utils.SendRuntimeStatusInfo))
+	b.NewPrivateCommandProcessor("help", wrap("command-help", ms.HelpMessage))
+	b.NewPrivateCommandProcessor("start", wrap("command-start", ms.StartMessage))
+	b.NewPrivateCommandProcessor("lang", wrap("command-lang", ms.LanguageChose))
+	b.NewCallBackProcessor(lib.SingleDownload.String(), wrap("callback-single", ms.ThisFormatChose))
+	b.NewCallBackProcessor("this", wrap("callback-this", ms.ThisFormatChose))
+	b.NewCallBackProcessor("zip", wrap("callback-zip", ms.ZipFormatChose))
+	b.NewCallBackProcessor(lib.SetDownload.String(), wrap("callback-set", ms.ZipFormatChose))
+	b.NewCallBackProcessor("cancel", wrap("callback-cancel", ms.CancelDownload))
 
-	// Single sticker download → show format chooser first
-	b.NewCallBackProcessor(lib.SingleDownload.String(), ms.ThisFormatChose)
-
-	// Format choosers
-	b.NewCallBackProcessor("this", ms.ThisFormatChose)
-	b.NewCallBackProcessor("zip", ms.ZipFormatChose)
-	b.NewCallBackProcessor(lib.SetDownload.String(), ms.ZipFormatChose) // "set" button from GenerateNewTaskMessage
-	b.NewCallBackProcessor("cancel", ms.CancelDownload)
-
-	// Single sticker format callbacks
-	formats := map[string]lib.TaskFileFormat{
-		"webp": lib.WebpFormat,
-		"png":  lib.PngFormat,
-		"jpeg": lib.JpegFormat,
+	formats := map[string]lib.TaskFileFormat{"webp": lib.WebpFormat, "png": lib.PngFormat, "jpeg": lib.JpegFormat}
+	for key, format := range formats {
+		b.NewCallBackProcessor(key, wrap("callback-"+key, func(u tgbotapi.Update) error { return ms.ThisSender(format, u) }))
+		b.NewCallBackProcessor("zip_"+key, wrap("callback-zip-"+key, func(u tgbotapi.Update) error { return ms.ZipSender(format, u) }))
 	}
-	for key, fmt := range formats {
-		fmt := fmt // capture
-		b.NewCallBackProcessor(key, func(u tgbotapi.Update) error {
-			return ms.ThisSender(fmt, u)
-		})
-		b.NewCallBackProcessor("zip_"+key, func(u tgbotapi.Update) error {
-			return ms.ZipSender(fmt, u)
-		})
+	for _, language := range []string{"zh", "en", "jp"} {
+		b.NewCallBackProcessor("lang_"+language, wrap("callback-lang-"+language, func(u tgbotapi.Update) error { return ms.ChangeUserLanguage(u, language) }))
 	}
+}
 
-	// Language callbacks
-	languages := []string{"zh", "en", "jp"}
-	for _, lang := range languages {
-		lang := lang // capture
-		b.NewCallBackProcessor("lang_"+lang, func(u tgbotapi.Update) error {
-			return ms.ChangeUserLanguage(u, lang)
-		})
+func isDownloadableStickerMessage(msg *tgbotapi.Message) bool {
+	if msg == nil || msg.From == nil {
+		return false
 	}
+	if msg.Sticker != nil {
+		return true
+	}
+	return stickerPackLinkRegex.MatchString(msg.Text)
 }

--- a/src/main.go
+++ b/src/main.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"regexp"
+	"runtime/debug"
 	"strings"
 	"syscall"
 	"time"
@@ -85,12 +86,19 @@ func runWorker(settings config.Settings, notifier *notify.Telegram) (exitCode in
 	runID := os.Getenv("STICKERDOWNLOADER_RUN_ID")
 	generation := os.Getenv("STICKERDOWNLOADER_GENERATION")
 	startedAt := time.Now()
+	utils.RuntimeStatus.StartTime = startedAt
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			logger.Error("worker 主流程 panic: %v", recovered)
+			stack := debug.Stack()
+			utils.RuntimeStatus.RecordError(lib.RuntimeErrorPanic)
+			logger.Error("worker 主流程 panic: %v\n%s", recovered, stack)
 			ctx, cancel := context.WithTimeout(context.Background(), settings.Notification.RequestTimeout)
-			_ = notifier.SendPanic(ctx, "worker-main", recovered, nil, "Run: "+runID+"\nGeneration: "+generation)
+			err := notifier.SendPanic(ctx, "worker-main", recovered, stack, "Run: "+runID+"\nGeneration: "+generation)
 			cancel()
+			if err != nil {
+				utils.RuntimeStatus.RecordError(lib.RuntimeErrorNotification)
+				logger.Error("发送 worker 主流程 panic 通知失败: %s", err)
+			}
 			exitCode = supervisor.ExitCrash
 		}
 	}()
@@ -132,11 +140,11 @@ func runWorker(settings config.Settings, notifier *notify.Telegram) (exitCode in
 	guard.Go("task-manager", runtimeguard.Critical, func() { task.TaskManager() })
 	guard.Go("telegram-polling", runtimeguard.Critical, func() { b.Run() })
 
-	utils.RuntimeStatus.StartTime = startedAt
 	workerPID := os.Getpid()
 	readyText := fmt.Sprintf("✅ StickerDownloader 已启动\nRun: %s\nGeneration: %s\nPID: %d\nVersion: %s\nCommit: %s", runID, generation, workerPID, version, commitHash)
 	notifyCtx, cancelNotify := context.WithTimeout(context.Background(), settings.Notification.RequestTimeout)
 	if err := notifier.SendEvent(notifyCtx, runID+":"+generation+":started", readyText); err != nil {
+		utils.RuntimeStatus.RecordError(lib.RuntimeErrorNotification)
 		logger.Warn("发送启动通知失败: %s", err)
 	}
 	cancelNotify()

--- a/src/main.go
+++ b/src/main.go
@@ -87,6 +87,7 @@ func runWorker(settings config.Settings, notifier *notify.Telegram) (exitCode in
 	generation := os.Getenv("STICKERDOWNLOADER_GENERATION")
 	startedAt := time.Now()
 	utils.RuntimeStatus.StartTime = startedAt
+	utils.DownloadHistory.SetCapacity(config.DownloadHistorySize)
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			stack := debug.Stack()
@@ -107,6 +108,16 @@ func runWorker(settings config.Settings, notifier *notify.Telegram) (exitCode in
 		logger.Error("数据库初始化失败: %s", err)
 		return supervisor.ExitTemporary
 	}
+	if records, err := db.LoadRecentDownloadRecords(config.DownloadHistorySize); err != nil {
+		logger.Warn("加载历史下载记录失败: %s", err)
+	} else {
+		utils.DownloadHistory.Seed(records)
+	}
+	utils.DownloadHistory.SetPersist(func(record lib.DownloadRecord) {
+		if err := db.SaveDownloadRecord(record, config.DownloadHistorySize); err != nil {
+			logger.Warn("保存下载记录失败: %s", err)
+		}
+	})
 	if err := core.InitBot(); err != nil {
 		logger.Error("Bot 初始化失败: %s", err)
 		return supervisor.ExitTemporary

--- a/src/notify/telegram.go
+++ b/src/notify/telegram.go
@@ -1,0 +1,210 @@
+package notify
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const maxTelegramMessageBytes = 4000
+
+type Config struct {
+	Token       string
+	OwnerChatID int64
+	APIEndpoint string
+	Timeout     time.Duration
+	DedupWindow time.Duration
+	MaxStack    int
+}
+
+type Telegram struct {
+	config Config
+	client *http.Client
+
+	mu          sync.Mutex
+	sentEvents  map[string]struct{}
+	panicEvents map[string]panicEvent
+}
+
+type panicEvent struct {
+	lastSent   time.Time
+	suppressed int
+}
+
+type apiResponse struct {
+	OK          bool   `json:"ok"`
+	Description string `json:"description"`
+}
+
+func New(config Config) *Telegram {
+	if config.Timeout <= 0 {
+		config.Timeout = 8 * time.Second
+	}
+	if config.DedupWindow <= 0 {
+		config.DedupWindow = 5 * time.Minute
+	}
+	if config.MaxStack <= 0 {
+		config.MaxStack = 8192
+	}
+	return &Telegram{
+		config:      config,
+		client:      &http.Client{Timeout: config.Timeout},
+		sentEvents:  make(map[string]struct{}),
+		panicEvents: make(map[string]panicEvent),
+	}
+}
+
+func NewWithClient(config Config, client *http.Client) *Telegram {
+	n := New(config)
+	if client != nil {
+		n.client = client
+	}
+	return n
+}
+
+func (n *Telegram) Enabled() bool {
+	return n != nil && n.config.OwnerChatID != 0 && n.config.Token != ""
+}
+
+func (n *Telegram) Send(ctx context.Context, text string) error {
+	if !n.Enabled() {
+		return nil
+	}
+	text = truncateUTF8(text, maxTelegramMessageBytes)
+	values := url.Values{}
+	values.Set("chat_id", strconv.FormatInt(n.config.OwnerChatID, 10))
+	values.Set("text", text)
+	values.Set("disable_web_page_preview", "true")
+
+	endpoint := fmt.Sprintf(n.config.APIEndpoint, n.config.Token, "sendMessage")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(values.Encode()))
+	if err != nil {
+		return fmt.Errorf("创建 Telegram 通知请求: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("发送 Telegram 通知失败: %T", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	if err != nil {
+		return fmt.Errorf("读取 Telegram 通知响应: %w", err)
+	}
+	var result apiResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return fmt.Errorf("解析 Telegram 通知响应: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 || !result.OK {
+		return fmt.Errorf("Telegram 通知失败: status=%d description=%s", resp.StatusCode, truncateUTF8(result.Description, 256))
+	}
+	return nil
+}
+
+func (n *Telegram) SendEvent(ctx context.Context, key, text string) error {
+	if !n.Enabled() {
+		return nil
+	}
+	n.mu.Lock()
+	if _, exists := n.sentEvents[key]; exists {
+		n.mu.Unlock()
+		return nil
+	}
+	n.sentEvents[key] = struct{}{}
+	n.mu.Unlock()
+
+	if err := n.Send(ctx, text); err != nil {
+		n.mu.Lock()
+		delete(n.sentEvents, key)
+		n.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+func (n *Telegram) SendPanic(ctx context.Context, component string, recovered any, stack []byte, metadata string) error {
+	if !n.Enabled() {
+		return nil
+	}
+	panicText := truncateUTF8(fmt.Sprint(recovered), 512)
+	stack = truncateBytes(stack, n.config.MaxStack)
+	fingerprint := panicFingerprint(component, panicText, stack)
+	now := time.Now()
+
+	n.mu.Lock()
+	event := n.panicEvents[fingerprint]
+	if !event.lastSent.IsZero() && now.Sub(event.lastSent) < n.config.DedupWindow {
+		event.suppressed++
+		n.panicEvents[fingerprint] = event
+		n.mu.Unlock()
+		return nil
+	}
+	suppressed := event.suppressed
+	n.panicEvents[fingerprint] = panicEvent{lastSent: now}
+	n.mu.Unlock()
+
+	message := fmt.Sprintf("🚨 任务发生 panic\n组件: %s\n摘要: %s\n事件: %s", component, panicText, fingerprint)
+	if metadata != "" {
+		message += "\n" + truncateUTF8(metadata, 512)
+	}
+	if suppressed > 0 {
+		message += fmt.Sprintf("\n已抑制重复事件: %d", suppressed)
+	}
+	if len(stack) > 0 {
+		message += "\n\nStack:\n" + string(stack)
+	}
+	if err := n.Send(ctx, message); err != nil {
+		n.mu.Lock()
+		current := n.panicEvents[fingerprint]
+		current.lastSent = event.lastSent
+		current.suppressed += suppressed
+		n.panicEvents[fingerprint] = current
+		n.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+func panicFingerprint(component, panicText string, stack []byte) string {
+	stackLines := strings.Split(string(stack), "\n")
+	if len(stackLines) > 0 && strings.HasPrefix(stackLines[0], "goroutine ") {
+		stackLines = stackLines[1:]
+	}
+	if len(stackLines) > 12 {
+		stackLines = stackLines[:12]
+	}
+	hash := sha256.Sum256([]byte(component + "\x00" + panicText + "\x00" + strings.Join(stackLines, "\n")))
+	return hex.EncodeToString(hash[:6])
+}
+
+func truncateBytes(data []byte, limit int) []byte {
+	if limit <= 0 || len(data) <= limit {
+		return data
+	}
+	return data[:limit]
+}
+
+func truncateUTF8(value string, maxBytes int) string {
+	if maxBytes <= 0 || len(value) <= maxBytes {
+		return value
+	}
+	for maxBytes > 0 && (value[maxBytes]&0xc0) == 0x80 {
+		maxBytes--
+	}
+	if maxBytes == 0 {
+		return ""
+	}
+	return value[:maxBytes] + "…"
+}
+
+var ErrDisabled = errors.New("通知未启用")

--- a/src/notify/telegram_test.go
+++ b/src/notify/telegram_test.go
@@ -1,0 +1,94 @@
+package notify
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSendUsesOnlySendMessage(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if !strings.HasSuffix(r.URL.Path, "/sendMessage") {
+			t.Fatalf("unexpected endpoint: %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), "chat_id=42") {
+			t.Fatalf("missing chat id: %s", body)
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"result":{}}`))
+	}))
+	defer server.Close()
+
+	n := New(Config{
+		Token:       "fake-token",
+		OwnerChatID: 42,
+		APIEndpoint: server.URL + "/bot%s/%s",
+		Timeout:     time.Second,
+	})
+	if err := n.Send(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls = %d", calls.Load())
+	}
+}
+
+func TestDisabledOwnerDoesNotSend(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+	}))
+	defer server.Close()
+
+	n := New(Config{Token: "fake-token", APIEndpoint: server.URL + "/bot%s/%s"})
+	if err := n.Send(context.Background(), "ignored"); err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("calls = %d", calls.Load())
+	}
+}
+
+func TestSendEventDeduplicates(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	n := New(Config{Token: "fake-token", OwnerChatID: 1, APIEndpoint: server.URL + "/bot%s/%s"})
+	for range 2 {
+		if err := n.SendEvent(context.Background(), "run:1:started", "started"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls = %d", calls.Load())
+	}
+}
+
+func TestErrorDoesNotExposeToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"ok":false,"description":"upstream unavailable"}`))
+	}))
+	server.Close()
+
+	const token = "super-secret-token"
+	n := New(Config{Token: token, OwnerChatID: 1, APIEndpoint: server.URL + "/bot%s/%s", Timeout: 50 * time.Millisecond})
+	err := n.Send(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("error exposed token: %v", err)
+	}
+}

--- a/src/notify/telegram_test.go
+++ b/src/notify/telegram_test.go
@@ -75,6 +75,37 @@ func TestSendEventDeduplicates(t *testing.T) {
 	}
 }
 
+func TestSendPanicRetriesAfterFailure(t *testing.T) {
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := calls.Add(1)
+		if call == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(`{"ok":false,"description":"temporary failure"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"result":{}}`))
+	}))
+	defer server.Close()
+
+	n := New(Config{
+		Token:       "fake-token",
+		OwnerChatID: 1,
+		APIEndpoint: server.URL + "/bot%s/%s",
+		DedupWindow: time.Hour,
+	})
+	stack := []byte("goroutine 1 [running]:\nexample.fn()\n\t/example.go:10")
+	if err := n.SendPanic(context.Background(), "component", "boom", stack, "Run: test"); err == nil {
+		t.Fatal("expected first send to fail")
+	}
+	if err := n.SendPanic(context.Background(), "component", "boom", stack, "Run: test"); err != nil {
+		t.Fatalf("second send failed: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("calls = %d, want 2", got)
+	}
+}
+
 func TestErrorDoesNotExposeToken(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadGateway)

--- a/src/runtimeguard/runtimeguard.go
+++ b/src/runtimeguard/runtimeguard.go
@@ -1,0 +1,116 @@
+package runtimeguard
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"runtime/debug"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/swim233/StickerDownloader/logger"
+	"github.com/swim233/StickerDownloader/notify"
+	"github.com/swim233/StickerDownloader/utils"
+)
+
+type Severity int
+
+const (
+	Task Severity = iota
+	Critical
+)
+
+type Guard struct {
+	Notifier      *notify.Telegram
+	Fatal         chan<- error
+	RunID         string
+	Generation    string
+	StartTime     time.Time
+	NotifyTimeout time.Duration
+	WaitGroup     *sync.WaitGroup
+}
+
+type PanicError struct {
+	Component string
+	Recovered any
+	Stack     []byte
+}
+
+func (e *PanicError) Error() string {
+	return fmt.Sprintf("critical component %s panic: %v", e.Component, e.Recovered)
+}
+
+var defaultGuard atomic.Pointer[Guard]
+
+func SetDefault(guard *Guard) {
+	defaultGuard.Store(guard)
+}
+
+func Go(name string, severity Severity, fn func()) {
+	guard := defaultGuard.Load()
+	if guard == nil {
+		guard = &Guard{StartTime: time.Now()}
+	}
+	guard.Go(name, severity, fn)
+}
+
+func (g *Guard) Go(name string, severity Severity, fn func()) {
+	if g != nil && g.WaitGroup != nil {
+		g.WaitGroup.Add(1)
+	}
+	go func() {
+		if g != nil && g.WaitGroup != nil {
+			defer g.WaitGroup.Done()
+		}
+		defer g.recover(name, severity)
+		fn()
+	}()
+}
+
+func (g *Guard) Wrap(name string, fn func() error) func() error {
+	return func() (err error) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				g.handle(name, Task, recovered, debug.Stack())
+				err = fmt.Errorf("%s panic: %v", name, recovered)
+			}
+		}()
+		return fn()
+	}
+}
+
+func (g *Guard) recover(name string, severity Severity) {
+	if recovered := recover(); recovered != nil {
+		g.handle(name, severity, recovered, debug.Stack())
+	}
+}
+
+func (g *Guard) handle(name string, severity Severity, recovered any, stack []byte) {
+	utils.RuntimeStatus.Errors.Add(1)
+	func() {
+		defer func() {
+			if recover() != nil {
+				log.Printf("组件 %s panic: %v\n%s", name, recovered, stack)
+			}
+		}()
+		logger.Error("组件 %s panic: %v\n%s", name, recovered, stack)
+	}()
+
+	if g != nil && g.Notifier != nil {
+		metadata := fmt.Sprintf("Run: %s\nGeneration: %s\nUptime: %s\nSeverity: %d", g.RunID, g.Generation, time.Since(g.StartTime).Round(time.Second), severity)
+		timeout := g.NotifyTimeout
+		if timeout <= 0 {
+			timeout = 8 * time.Second
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		_ = g.Notifier.SendPanic(ctx, name, recovered, stack, metadata)
+		cancel()
+	}
+	if severity == Critical && g != nil && g.Fatal != nil {
+		select {
+		case g.Fatal <- &PanicError{Component: name, Recovered: recovered, Stack: stack}:
+		default:
+		}
+	}
+}

--- a/src/runtimeguard/runtimeguard.go
+++ b/src/runtimeguard/runtimeguard.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/swim233/StickerDownloader/lib"
 	"github.com/swim233/StickerDownloader/logger"
 	"github.com/swim233/StickerDownloader/notify"
 	"github.com/swim233/StickerDownloader/utils"
@@ -86,16 +87,18 @@ func (g *Guard) recover(name string, severity Severity) {
 	}
 }
 
-func (g *Guard) handle(name string, severity Severity, recovered any, stack []byte) {
-	utils.RuntimeStatus.Errors.Add(1)
-	func() {
-		defer func() {
-			if recover() != nil {
-				log.Printf("组件 %s panic: %v\n%s", name, recovered, stack)
-			}
-		}()
-		logger.Error("组件 %s panic: %v\n%s", name, recovered, stack)
+func logSafely(format string, args ...any) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			log.Printf(format, args...)
+		}
 	}()
+	logger.Error(format, args...)
+}
+
+func (g *Guard) handle(name string, severity Severity, recovered any, stack []byte) {
+	utils.RuntimeStatus.RecordError(lib.RuntimeErrorPanic)
+	logSafely("组件 %s panic: %v\n%s", name, recovered, stack)
 
 	if g != nil && g.Notifier != nil {
 		metadata := fmt.Sprintf("Run: %s\nGeneration: %s\nUptime: %s\nSeverity: %d", g.RunID, g.Generation, time.Since(g.StartTime).Round(time.Second), severity)
@@ -104,8 +107,12 @@ func (g *Guard) handle(name string, severity Severity, recovered any, stack []by
 			timeout = 8 * time.Second
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		_ = g.Notifier.SendPanic(ctx, name, recovered, stack, metadata)
+		err := g.Notifier.SendPanic(ctx, name, recovered, stack, metadata)
 		cancel()
+		if err != nil {
+			utils.RuntimeStatus.RecordError(lib.RuntimeErrorNotification)
+			logSafely("发送组件 %s panic 通知失败: %s", name, err)
+		}
 	}
 	if severity == Critical && g != nil && g.Fatal != nil {
 		select {

--- a/src/runtimeguard/runtimeguard_test.go
+++ b/src/runtimeguard/runtimeguard_test.go
@@ -1,0 +1,33 @@
+package runtimeguard
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTaskPanicDoesNotSignalFatal(t *testing.T) {
+	fatal := make(chan error, 1)
+	var wg sync.WaitGroup
+	guard := &Guard{Fatal: fatal, WaitGroup: &wg, StartTime: time.Now()}
+	guard.Go("task", Task, func() { panic("boom") })
+	wg.Wait()
+	select {
+	case err := <-fatal:
+		t.Fatalf("unexpected fatal error: %v", err)
+	default:
+	}
+}
+
+func TestCriticalPanicSignalsFatal(t *testing.T) {
+	fatal := make(chan error, 1)
+	var wg sync.WaitGroup
+	guard := &Guard{Fatal: fatal, WaitGroup: &wg, StartTime: time.Now()}
+	guard.Go("critical", Critical, func() { panic("boom") })
+	wg.Wait()
+	select {
+	case <-fatal:
+	case <-time.After(time.Second):
+		t.Fatal("missing fatal signal")
+	}
+}

--- a/src/runtimeguard/runtimeguard_test.go
+++ b/src/runtimeguard/runtimeguard_test.go
@@ -1,12 +1,32 @@
 package runtimeguard
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/swim233/StickerDownloader/notify"
+	"github.com/swim233/StickerDownloader/utils"
 )
 
+func preserveErrorCounters(t *testing.T) {
+	t.Helper()
+	errors := utils.RuntimeStatus.Errors.Load()
+	panics := utils.RuntimeStatus.PanicErrors.Load()
+	notifications := utils.RuntimeStatus.NotificationErrors.Load()
+	t.Cleanup(func() {
+		utils.RuntimeStatus.Errors.Store(errors)
+		utils.RuntimeStatus.PanicErrors.Store(panics)
+		utils.RuntimeStatus.NotificationErrors.Store(notifications)
+	})
+}
+
 func TestTaskPanicDoesNotSignalFatal(t *testing.T) {
+	preserveErrorCounters(t)
+	beforeErrors := utils.RuntimeStatus.Errors.Load()
+	beforePanics := utils.RuntimeStatus.PanicErrors.Load()
 	fatal := make(chan error, 1)
 	var wg sync.WaitGroup
 	guard := &Guard{Fatal: fatal, WaitGroup: &wg, StartTime: time.Now()}
@@ -17,9 +37,17 @@ func TestTaskPanicDoesNotSignalFatal(t *testing.T) {
 		t.Fatalf("unexpected fatal error: %v", err)
 	default:
 	}
+	if got := utils.RuntimeStatus.Errors.Load(); got != beforeErrors+1 {
+		t.Fatalf("Errors = %d, want %d", got, beforeErrors+1)
+	}
+	if got := utils.RuntimeStatus.PanicErrors.Load(); got != beforePanics+1 {
+		t.Fatalf("PanicErrors = %d, want %d", got, beforePanics+1)
+	}
 }
 
 func TestCriticalPanicSignalsFatal(t *testing.T) {
+	preserveErrorCounters(t)
+	beforePanics := utils.RuntimeStatus.PanicErrors.Load()
 	fatal := make(chan error, 1)
 	var wg sync.WaitGroup
 	guard := &Guard{Fatal: fatal, WaitGroup: &wg, StartTime: time.Now()}
@@ -29,5 +57,90 @@ func TestCriticalPanicSignalsFatal(t *testing.T) {
 	case <-fatal:
 	case <-time.After(time.Second):
 		t.Fatal("missing fatal signal")
+	}
+	if got := utils.RuntimeStatus.PanicErrors.Load(); got != beforePanics+1 {
+		t.Fatalf("PanicErrors = %d, want %d", got, beforePanics+1)
+	}
+}
+
+func TestPanicNotificationSuccessDoesNotRecordFailure(t *testing.T) {
+	preserveErrorCounters(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"result":{}}`))
+	}))
+	defer server.Close()
+
+	notifier := notify.New(notify.Config{
+		Token:       "fake-token",
+		OwnerChatID: 1,
+		APIEndpoint: server.URL + "/bot%s/%s",
+	})
+	beforePanics := utils.RuntimeStatus.PanicErrors.Load()
+	beforeNotifications := utils.RuntimeStatus.NotificationErrors.Load()
+	guard := &Guard{Notifier: notifier, StartTime: time.Now()}
+
+	guard.handle("task", Task, "boom", []byte("stack"))
+
+	if got := utils.RuntimeStatus.PanicErrors.Load(); got != beforePanics+1 {
+		t.Fatalf("PanicErrors = %d, want %d", got, beforePanics+1)
+	}
+	if got := utils.RuntimeStatus.NotificationErrors.Load(); got != beforeNotifications {
+		t.Fatalf("NotificationErrors changed: %d -> %d", beforeNotifications, got)
+	}
+}
+
+func TestPanicNotificationFailureIsRecorded(t *testing.T) {
+	preserveErrorCounters(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"ok":false,"description":"unavailable"}`))
+	}))
+	defer server.Close()
+
+	notifier := notify.New(notify.Config{
+		Token:       "fake-token",
+		OwnerChatID: 1,
+		APIEndpoint: server.URL + "/bot%s/%s",
+		Timeout:     time.Second,
+	})
+	beforeErrors := utils.RuntimeStatus.Errors.Load()
+	beforePanics := utils.RuntimeStatus.PanicErrors.Load()
+	beforeNotifications := utils.RuntimeStatus.NotificationErrors.Load()
+	fatal := make(chan error, 1)
+	guard := &Guard{
+		Notifier:   notifier,
+		Fatal:      fatal,
+		StartTime:  time.Now(),
+		Generation: "1",
+	}
+
+	guard.handle("critical", Critical, "boom", []byte("stack"))
+
+	if got := utils.RuntimeStatus.Errors.Load(); got != beforeErrors+2 {
+		t.Fatalf("Errors = %d, want %d", got, beforeErrors+2)
+	}
+	if got := utils.RuntimeStatus.PanicErrors.Load(); got != beforePanics+1 {
+		t.Fatalf("PanicErrors = %d, want %d", got, beforePanics+1)
+	}
+	if got := utils.RuntimeStatus.NotificationErrors.Load(); got != beforeNotifications+1 {
+		t.Fatalf("NotificationErrors = %d, want %d", got, beforeNotifications+1)
+	}
+	select {
+	case <-fatal:
+	case <-time.After(time.Second):
+		t.Fatal("notification failure blocked fatal signal")
+	}
+}
+
+func TestWrapPanicReportsOnce(t *testing.T) {
+	preserveErrorCounters(t)
+	beforePanics := utils.RuntimeStatus.PanicErrors.Load()
+	guard := &Guard{StartTime: time.Now()}
+	err := guard.Wrap("callback", func() error { panic("boom") })()
+	if err == nil {
+		t.Fatal("expected wrapped panic error")
+	}
+	if got := utils.RuntimeStatus.PanicErrors.Load(); got != beforePanics+1 {
+		t.Fatalf("PanicErrors = %d, want %d", got, beforePanics+1)
 	}
 }

--- a/src/supervisor/policy.go
+++ b/src/supervisor/policy.go
@@ -1,0 +1,54 @@
+package supervisor
+
+import (
+	"math"
+	"math/rand/v2"
+	"time"
+
+	"github.com/swim233/StickerDownloader/config"
+)
+
+type Policy struct {
+	settings config.RestartSettings
+	crashes  []time.Time
+	streak   int
+}
+
+func NewPolicy(settings config.RestartSettings) *Policy {
+	return &Policy{settings: settings}
+}
+
+func (p *Policy) RecordCrash(startedAt, now time.Time) (delay time.Duration, cooldown bool) {
+	if now.Sub(startedAt) >= p.settings.StableAfter {
+		p.streak = 0
+		p.crashes = nil
+	}
+	p.streak++
+	cutoff := now.Add(-p.settings.Window)
+	kept := p.crashes[:0]
+	for _, crash := range p.crashes {
+		if !crash.Before(cutoff) {
+			kept = append(kept, crash)
+		}
+	}
+	p.crashes = append(kept, now)
+	if len(p.crashes) >= p.settings.MaxRestarts {
+		p.crashes = nil
+		return p.settings.Cooldown, true
+	}
+
+	power := math.Pow(p.settings.Multiplier, float64(p.streak-1))
+	delay = time.Duration(float64(p.settings.InitialDelay) * power)
+	if delay > p.settings.MaxDelay {
+		delay = p.settings.MaxDelay
+	}
+	if p.settings.Jitter > 0 {
+		factor := 1 + ((rand.Float64()*2)-1)*p.settings.Jitter
+		delay = time.Duration(float64(delay) * factor)
+	}
+	return delay, false
+}
+
+func ShouldRestart(exitCode int) bool {
+	return exitCode != ExitOK && exitCode != ExitUsage && exitCode != ExitConfig
+}

--- a/src/supervisor/policy_test.go
+++ b/src/supervisor/policy_test.go
@@ -1,0 +1,63 @@
+package supervisor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/swim233/StickerDownloader/config"
+)
+
+func TestPolicyBackoffAndCooldown(t *testing.T) {
+	settings := config.RestartSettings{
+		InitialDelay: time.Second,
+		MaxDelay:     time.Minute,
+		Multiplier:   2,
+		StableAfter:  10 * time.Minute,
+		MaxRestarts:  3,
+		Window:       5 * time.Minute,
+		Cooldown:     15 * time.Minute,
+	}
+	policy := NewPolicy(settings)
+	now := time.Now()
+
+	delay, cooldown := policy.RecordCrash(now, now.Add(time.Second))
+	if delay != time.Second || cooldown {
+		t.Fatalf("first crash: delay=%s cooldown=%v", delay, cooldown)
+	}
+	delay, cooldown = policy.RecordCrash(now, now.Add(2*time.Second))
+	if delay != 2*time.Second || cooldown {
+		t.Fatalf("second crash: delay=%s cooldown=%v", delay, cooldown)
+	}
+	delay, cooldown = policy.RecordCrash(now, now.Add(3*time.Second))
+	if delay != 15*time.Minute || !cooldown {
+		t.Fatalf("third crash: delay=%s cooldown=%v", delay, cooldown)
+	}
+}
+
+func TestPolicyResetsAfterStableRun(t *testing.T) {
+	settings := config.RestartSettings{
+		InitialDelay: time.Second,
+		MaxDelay:     time.Minute,
+		Multiplier:   2,
+		StableAfter:  10 * time.Minute,
+		MaxRestarts:  5,
+		Window:       5 * time.Minute,
+		Cooldown:     15 * time.Minute,
+	}
+	policy := NewPolicy(settings)
+	now := time.Now()
+	_, _ = policy.RecordCrash(now, now.Add(time.Second))
+	delay, cooldown := policy.RecordCrash(now, now.Add(11*time.Minute))
+	if delay != time.Second || cooldown {
+		t.Fatalf("stable reset: delay=%s cooldown=%v", delay, cooldown)
+	}
+}
+
+func TestShouldRestart(t *testing.T) {
+	if ShouldRestart(ExitOK) || ShouldRestart(ExitUsage) || ShouldRestart(ExitConfig) {
+		t.Fatal("permanent/normal exits must not restart")
+	}
+	if !ShouldRestart(ExitCrash) || !ShouldRestart(ExitTemporary) {
+		t.Fatal("crash/temporary exits must restart")
+	}
+}

--- a/src/supervisor/supervisor.go
+++ b/src/supervisor/supervisor.go
@@ -1,0 +1,184 @@
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/swim233/StickerDownloader/config"
+	"github.com/swim233/StickerDownloader/notify"
+)
+
+const (
+	ExitOK        = 0
+	ExitCrash     = 1
+	ExitUsage     = 64
+	ExitTemporary = 75
+	ExitConfig    = 78
+)
+
+type Runner struct {
+	Executable string
+	ConfigPath string
+	Settings   config.Settings
+	Notifier   *notify.Telegram
+	RunID      string
+
+	mu      sync.Mutex
+	current *exec.Cmd
+}
+
+func New(executable, configPath string, settings config.Settings, notifier *notify.Telegram) *Runner {
+	return &Runner{
+		Executable: executable,
+		ConfigPath: configPath,
+		Settings:   settings,
+		Notifier:   notifier,
+		RunID:      uuid.NewString(),
+	}
+}
+
+func (r *Runner) Run(parent context.Context) int {
+	ctx, stop := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	policy := NewPolicy(r.Settings.Supervisor.Restart)
+	generation := 0
+	var stopOnce sync.Once
+
+	for {
+		if ctx.Err() != nil {
+			stopOnce.Do(func() { r.notify("stopped", generation, "🛑 StickerDownloader 已正常停止") })
+			return ExitOK
+		}
+		generation++
+		startedAt := time.Now()
+		cmd := exec.Command(r.Executable, "--worker", "--config", r.ConfigPath)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		cmd.Env = append(os.Environ(),
+			"STICKERDOWNLOADER_RUN_ID="+r.RunID,
+			"STICKERDOWNLOADER_GENERATION="+strconv.Itoa(generation),
+		)
+
+		if generation > 1 {
+			r.notify("restarting", generation, fmt.Sprintf("🔄 正在重启 StickerDownloader\nRun: %s\nGeneration: %d", r.RunID, generation))
+		}
+		if err := cmd.Start(); err != nil {
+			log.Printf("启动 worker 失败: %v", err)
+			r.notify("start-failed", generation, fmt.Sprintf("❌ Worker 启动失败\nGeneration: %d\n错误: %s", generation, safeError(err)))
+			if !r.waitAfterCrash(ctx, policy, generation, startedAt) {
+				stopOnce.Do(func() { r.notify("stopped", generation, "🛑 StickerDownloader 已正常停止") })
+				return ExitOK
+			}
+			continue
+		}
+		r.setCurrent(cmd)
+
+		waitCh := make(chan error, 1)
+		go func() { waitCh <- cmd.Wait() }()
+		var waitErr error
+		select {
+		case waitErr = <-waitCh:
+			r.setCurrent(nil)
+		case <-ctx.Done():
+			r.forwardStop(cmd, waitCh)
+			r.setCurrent(nil)
+			stopOnce.Do(func() { r.notify("stopped", generation, "🛑 StickerDownloader 已正常停止") })
+			return ExitOK
+		}
+
+		exitCode := commandExitCode(waitErr)
+		if exitCode == ExitOK {
+			stopOnce.Do(func() { r.notify("stopped", generation, "🛑 StickerDownloader 已正常停止") })
+			return ExitOK
+		}
+		r.notify("crashed", generation, fmt.Sprintf("💥 Worker 意外退出\nRun: %s\nGeneration: %d\nPID: %d\n退出码: %d\n运行时长: %s", r.RunID, generation, cmd.Process.Pid, exitCode, time.Since(startedAt).Round(time.Second)))
+		if !ShouldRestart(exitCode) {
+			r.notify("permanent-failure", generation, fmt.Sprintf("⛔ Worker 遇到永久错误，不会自动重启\n退出码: %d", exitCode))
+			return exitCode
+		}
+		if !r.waitAfterCrash(ctx, policy, generation, startedAt) {
+			stopOnce.Do(func() { r.notify("stopped", generation, "🛑 StickerDownloader 已正常停止") })
+			return ExitOK
+		}
+	}
+}
+
+func (r *Runner) waitAfterCrash(ctx context.Context, policy *Policy, generation int, startedAt time.Time) bool {
+	delay, cooldown := policy.RecordCrash(startedAt, time.Now())
+	if cooldown {
+		r.notify("crash-loop", generation, fmt.Sprintf("⚠️ 检测到崩溃循环，暂停重启 %s", delay))
+	} else {
+		r.notify("restart-scheduled", generation, fmt.Sprintf("⏳ Worker 将在 %s 后重启", delay.Round(time.Millisecond)))
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (r *Runner) forwardStop(cmd *exec.Cmd, waitCh <-chan error) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	timer := time.NewTimer(r.Settings.Supervisor.ShutdownTimeout)
+	defer timer.Stop()
+	select {
+	case <-waitCh:
+		return
+	case <-timer.C:
+		_ = cmd.Process.Kill()
+		<-waitCh
+	}
+}
+
+func (r *Runner) setCurrent(cmd *exec.Cmd) {
+	r.mu.Lock()
+	r.current = cmd
+	r.mu.Unlock()
+}
+
+func (r *Runner) notify(event string, generation int, text string) {
+	if r.Notifier == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), r.Settings.Notification.RequestTimeout)
+	defer cancel()
+	key := fmt.Sprintf("%s:%d:%s", r.RunID, generation, event)
+	if err := r.Notifier.SendEvent(ctx, key, text); err != nil {
+		log.Printf("发送 Owner 通知失败: %v", err)
+	}
+}
+
+func commandExitCode(err error) int {
+	if err == nil {
+		return ExitOK
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return ExitCrash
+}
+
+func safeError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return fmt.Sprintf("%T", err)
+}

--- a/src/task/file_handler.go
+++ b/src/task/file_handler.go
@@ -25,6 +25,7 @@ func getUrl(fileID string) (string, error) {
 			lastErr = err
 			continue
 		}
+		logger.Debug("已解析 Telegram 文件路径")
 		return fmt.Sprintf("https://api.telegram.org/file/bot%s/%s", config.BotToken, file.FilePath), nil
 	}
 	return "", lastErr
@@ -32,11 +33,13 @@ func getUrl(fileID string) (string, error) {
 
 // getSetUrl resolves a sticker's file URL.
 func getSetUrl(sticker tgbotapi.Sticker) (string, error) {
+
 	return getUrl(sticker.FileID)
 }
 
 // getStickerSetName extracts the sticker set name from a callback query.
 func getStickerSetName(u tgbotapi.Update) string {
+
 	var stickerLinkRegex = regexp.MustCompile(`https://t.me/addstickers/([a-zA-Z0-9_]+)`)
 
 	if u.CallbackQuery != nil && u.CallbackQuery.Message.ReplyToMessage.Sticker != nil {

--- a/src/task/task_manager.go
+++ b/src/task/task_manager.go
@@ -6,15 +6,17 @@ import (
 	"github.com/google/uuid"
 	tgbotapi "github.com/ijnkawakaze/telegram-bot-api"
 	"github.com/swim233/StickerDownloader/lib"
+	"github.com/swim233/StickerDownloader/runtimeguard"
 	"github.com/swim233/StickerDownloader/utils"
 )
 
 var TaskChan = make(chan lib.Task, 32)
 
 func TaskManager() {
-	for {
-		task := <-TaskChan
-		go TaskHandler(task, context.Background())
+	for task := range TaskChan {
+		runtimeguard.Go("task-handler", runtimeguard.Task, func() {
+			TaskHandler(task, context.Background())
+		})
 	}
 }
 

--- a/src/utils/download_history.go
+++ b/src/utils/download_history.go
@@ -1,0 +1,7 @@
+package utils
+
+import "github.com/swim233/StickerDownloader/lib"
+
+// DownloadHistory keeps the most recent downloads for the WebUI history view.
+// Capacity is applied from config at worker startup via SetCapacity.
+var DownloadHistory = lib.NewDownloadHistory(lib.DefaultDownloadHistorySize)

--- a/src/utils/runtime_status.go
+++ b/src/utils/runtime_status.go
@@ -40,6 +40,47 @@ func currentRuntimeStatus() runtimeStatusSnapshot {
 	}
 }
 
+// RuntimeStatusReport is the JSON shape served by the WebUI status API.
+type RuntimeStatusReport struct {
+	StartTime          time.Time `json:"start_time"`
+	UptimeSeconds      int64     `json:"uptime_seconds"`
+	SingleDownload     int64     `json:"single_download"`
+	PackDownload       int64     `json:"pack_download"`
+	HTTPSingleDownload int64     `json:"http_single_download"`
+	HTTPPackDownload   int64     `json:"http_pack_download"`
+	CacheHits          int64     `json:"cache_hits"`
+	CacheHitRate       float64   `json:"cache_hit_rate"`
+	TotalErrors        int64     `json:"total_errors"`
+	PanicErrors        int64     `json:"panic_errors"`
+	RequestErrors      int64     `json:"request_errors"`
+	DownloadErrors     int64     `json:"download_errors"`
+	NotificationErrors int64     `json:"notification_errors"`
+}
+
+// CurrentRuntimeStatusReport snapshots the runtime counters for the WebUI.
+func CurrentRuntimeStatusReport(now time.Time) RuntimeStatusReport {
+	status := currentRuntimeStatus()
+	var hitRate float64
+	if totalPacks := status.packDownload + status.httpPackDownload; totalPacks > 0 {
+		hitRate = float64(status.cacheHits) / float64(totalPacks) * 100
+	}
+	return RuntimeStatusReport{
+		StartTime:          status.startTime,
+		UptimeSeconds:      int64(now.Sub(status.startTime).Seconds()),
+		SingleDownload:     status.singleDownload,
+		PackDownload:       status.packDownload,
+		HTTPSingleDownload: status.httpSingleDownload,
+		HTTPPackDownload:   status.httpPackDownload,
+		CacheHits:          status.cacheHits,
+		CacheHitRate:       hitRate,
+		TotalErrors:        status.panicErrors + status.requestErrors + status.downloadErrors + status.notificationErrors,
+		PanicErrors:        status.panicErrors,
+		RequestErrors:      status.requestErrors,
+		DownloadErrors:     status.downloadErrors,
+		NotificationErrors: status.notificationErrors,
+	}
+}
+
 func formatRuntimeStatus(status runtimeStatusSnapshot, now time.Time) string {
 	var hitPercentage float64
 	totalPacks := status.packDownload + status.httpPackDownload

--- a/src/utils/runtime_status.go
+++ b/src/utils/runtime_status.go
@@ -7,35 +7,48 @@ import (
 	tgbotapi "github.com/ijnkawakaze/telegram-bot-api"
 	"github.com/swim233/StickerDownloader/core"
 	"github.com/swim233/StickerDownloader/lib"
+	"github.com/swim233/StickerDownloader/logger"
 )
 
 var RuntimeStatus lib.RuntimeStatus
 
-// SendRuntimeStatusInfo sends runtime statistics to the requesting user.
-func SendRuntimeStatusInfo(u tgbotapi.Update) error {
-	// Bug fix: was `!= nil` which returned early when user exists
-	if u.Message.From == nil {
-		return nil
+type runtimeStatusSnapshot struct {
+	startTime          time.Time
+	singleDownload     int64
+	packDownload       int64
+	httpSingleDownload int64
+	httpPackDownload   int64
+	cacheHits          int64
+	panicErrors        int64
+	requestErrors      int64
+	downloadErrors     int64
+	notificationErrors int64
+}
+
+func currentRuntimeStatus() runtimeStatusSnapshot {
+	return runtimeStatusSnapshot{
+		startTime:          RuntimeStatus.StartTime,
+		singleDownload:     RuntimeStatus.SingleDownload.Load(),
+		packDownload:       RuntimeStatus.PackDownload.Load(),
+		httpSingleDownload: RuntimeStatus.HTTPSingleDownload.Load(),
+		httpPackDownload:   RuntimeStatus.HTTPPackDownload.Load(),
+		cacheHits:          RuntimeStatus.CacheHits.Load(),
+		panicErrors:        RuntimeStatus.PanicErrors.Load(),
+		requestErrors:      RuntimeStatus.RequestErrors.Load(),
+		downloadErrors:     RuntimeStatus.DownloadErrors.Load(),
+		notificationErrors: RuntimeStatus.NotificationErrors.Load(),
 	}
-	chatID := u.Message.From.ID
+}
 
-	singleDL := RuntimeStatus.SingleDownload.Load()
-	packDL := RuntimeStatus.PackDownload.Load()
-	httpSingleDL := RuntimeStatus.HTTPSingleDownload.Load()
-	httpPackDL := RuntimeStatus.HTTPPackDownload.Load()
-	cacheHits := RuntimeStatus.CacheHits.Load()
-	errors := RuntimeStatus.Errors.Load()
-
+func formatRuntimeStatus(status runtimeStatusSnapshot, now time.Time) string {
 	var hitPercentage float64
-	totalPacks := packDL + httpPackDL
+	totalPacks := status.packDownload + status.httpPackDownload
 	if totalPacks > 0 {
-		hitPercentage = float64(cacheHits) / float64(totalPacks) * 100
+		hitPercentage = float64(status.cacheHits) / float64(totalPacks) * 100
 	}
 
-	duration := time.Since(RuntimeStatus.StartTime)
-	timeStr := formatDuration(duration)
-
-	text := fmt.Sprintf(
+	totalErrors := status.panicErrors + status.requestErrors + status.downloadErrors + status.notificationErrors
+	return fmt.Sprintf(
 		"启动时间 : %s\n"+
 			"本次运行时间 : %s\n"+
 			"机器人已下载贴纸总数 : %d\n"+
@@ -44,14 +57,31 @@ func SendRuntimeStatusInfo(u tgbotapi.Update) error {
 			"HTTP服务器已下载贴纸包数 : %d\n"+
 			"缓存生效次数 : %d\n"+
 			"缓存命中率 : %.1f%%\n"+
-			"发生错误数 : %d",
-		RuntimeStatus.StartTime.Format("2006-01-02 15:04:05"),
-		timeStr, singleDL, packDL, httpSingleDL, httpPackDL,
-		cacheHits, hitPercentage, errors,
+			"当前 Worker 错误总数 : %d\n"+
+			"  Panic : %d\n"+
+			"  过期/请求 : %d\n"+
+			"  下载 : %d\n"+
+			"  通知失败 : %d",
+		status.startTime.Format("2006-01-02 15:04:05"),
+		formatDuration(now.Sub(status.startTime)),
+		status.singleDownload, status.packDownload, status.httpSingleDownload, status.httpPackDownload,
+		status.cacheHits, hitPercentage, totalErrors,
+		status.panicErrors, status.requestErrors, status.downloadErrors, status.notificationErrors,
 	)
+}
 
-	msg := tgbotapi.NewMessage(chatID, text)
-	core.Bot.Send(msg)
+// SendRuntimeStatusInfo sends runtime statistics to the requesting user.
+func SendRuntimeStatusInfo(u tgbotapi.Update) error {
+	if u.Message == nil || u.Message.From == nil {
+		return nil
+	}
+
+	msg := tgbotapi.NewMessage(u.Message.From.ID, formatRuntimeStatus(currentRuntimeStatus(), time.Now()))
+	if _, err := core.Bot.Send(msg); err != nil {
+		RuntimeStatus.RecordError(lib.RuntimeErrorNotification)
+		logger.Warn("发送运行状态消息失败: %s", err)
+		return fmt.Errorf("发送运行状态消息: %w", err)
+	}
 	return nil
 }
 

--- a/src/utils/runtime_status_test.go
+++ b/src/utils/runtime_status_test.go
@@ -1,0 +1,95 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	tgbotapi "github.com/ijnkawakaze/telegram-bot-api"
+	"github.com/swim233/StickerDownloader/core"
+	"github.com/swim233/StickerDownloader/logger"
+)
+
+func TestFormatRuntimeStatusIncludesErrorCategories(t *testing.T) {
+	start := time.Date(2026, 7, 20, 10, 0, 0, 0, time.Local)
+	text := formatRuntimeStatus(runtimeStatusSnapshot{
+		startTime:          start,
+		singleDownload:     10,
+		packDownload:       2,
+		httpPackDownload:   2,
+		cacheHits:          1,
+		panicErrors:        1,
+		requestErrors:      2,
+		downloadErrors:     3,
+		notificationErrors: 4,
+	}, start.Add(time.Hour+2*time.Minute+3*time.Second))
+
+	for _, want := range []string{
+		"本次运行时间 : 1时2分3秒",
+		"缓存命中率 : 25.0%",
+		"当前 Worker 错误总数 : 10",
+		"Panic : 1",
+		"过期/请求 : 2",
+		"下载 : 3",
+		"通知失败 : 4",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("status text missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestSendRuntimeStatusInfoIgnoresMissingMessage(t *testing.T) {
+	if err := SendRuntimeStatusInfo(tgbotapi.Update{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SendRuntimeStatusInfo(tgbotapi.Update{Message: &tgbotapi.Message{}}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSendRuntimeStatusInfoRecordsSendFailure(t *testing.T) {
+	logger.InitLogger()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/getMe") {
+			_, _ = w.Write([]byte(`{"ok":true,"result":{"id":1,"is_bot":true,"first_name":"test","username":"test_bot"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"ok":false,"description":"unavailable"}`))
+	}))
+	defer server.Close()
+
+	bot, err := tgbotapi.NewBotAPIWithAPIEndpoint("test-token", server.URL+"/bot%s/%s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldBot := core.Bot
+	core.Bot = bot
+	defer func() { core.Bot = oldBot }()
+
+	oldErrors := RuntimeStatus.Errors.Load()
+	oldNotifications := RuntimeStatus.NotificationErrors.Load()
+	oldStart := RuntimeStatus.StartTime
+	RuntimeStatus.StartTime = time.Now()
+	defer func() {
+		RuntimeStatus.Errors.Store(oldErrors)
+		RuntimeStatus.NotificationErrors.Store(oldNotifications)
+		RuntimeStatus.StartTime = oldStart
+	}()
+
+	err = SendRuntimeStatusInfo(tgbotapi.Update{Message: &tgbotapi.Message{
+		From: &tgbotapi.User{ID: 42},
+	}})
+	if err == nil {
+		t.Fatal("expected send error")
+	}
+	if got := RuntimeStatus.Errors.Load(); got != oldErrors+1 {
+		t.Fatalf("Errors = %d, want %d", got, oldErrors+1)
+	}
+	if got := RuntimeStatus.NotificationErrors.Load(); got != oldNotifications+1 {
+		t.Fatalf("NotificationErrors = %d, want %d", got, oldNotifications+1)
+	}
+}


### PR DESCRIPTION
## Summary
- Supervised worker restarts with exponential backoff and Telegram owner alerts on panics/restarts
- Categorized runtime error counters (panic / request / download / notification) surfaced in /count and the status API
- Hardened callback handling against expired or incomplete callback contexts
- New WebUI at the HTTP server root: recent download history (last N, `server.history_size`, persisted in SQLite across restarts) with user, sticker set, and sticker details, plus runtime stats
- Password auth for the WebUI (`server.password`), HttpOnly session cookies, constant-time comparison, locked down when unconfigured

## Test plan
- `go build ./... && go vet ./... && go test ./...` all green (new tests for history buffer, persistence, auth, handlers, runtimeguard, notify)
- WebUI verified in browser (dark mode, login overlay, long-title wrapping, empty states) with mock data

🤖 Generated with [Claude Code](https://claude.com/claude-code)